### PR TITLE
feat(address): 배송지 주소 CRUD API 및 Service, Repository 테스트 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,12 @@ public class AddressController {
 		@AuthenticationPrincipal UserDetailsImpl user
 	) {
 		return addressService.updateAddress(id, requestDto, user);
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deleteAddress(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl user) {
+		addressService.deleteAddress(id, user);
+		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 
 

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -1,0 +1,33 @@
+package com.sparta.delivery.backend.address.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.service.AddressService;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/addresses")
+public class AddressController {
+
+	private final AddressService addressService;
+
+	@PostMapping
+	public ResponseEntity<Void> registerAddress(
+		@RequestBody ReqRegisterAddressDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl user
+	) {
+		addressService.registerAddress(requestDto, user);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+}

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +23,7 @@ import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.service.AddressService;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,7 +35,7 @@ public class AddressController {
 
 	@PostMapping
 	public ResponseEntity<Void> registerAddress(
-		@RequestBody ReqRegisterAddressDto requestDto,
+		@Valid @RequestBody ReqRegisterAddressDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl user
 	) {
 		addressService.registerAddress(requestDto, user);
@@ -49,7 +51,7 @@ public class AddressController {
 	@PutMapping("/{id}")
 	public ResAddressDto updateAddress(
 		@PathVariable UUID id,
-		@RequestBody ReqUpdateAddressDto requestDto,
+		@Valid @RequestBody ReqUpdateAddressDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl user
 	) {
 		return addressService.updateAddress(id, requestDto, user);

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,6 +45,7 @@ public class AddressController {
 		return addressService.getMyAddresses(user);
 	}
 
+	@PreAuthorize("@addressPermissionEvaluator.isOwner(#id, authentication.principal)")
 	@PutMapping("/{id}")
 	public ResAddressDto updateAddress(
 		@PathVariable UUID id,
@@ -53,12 +55,11 @@ public class AddressController {
 		return addressService.updateAddress(id, requestDto, user);
 	}
 
+	@PreAuthorize("@addressPermissionEvaluator.isOwner(#id, authentication.principal)")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> deleteAddress(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl user) {
 		addressService.deleteAddress(id, user);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
-
-
 
 }

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -50,17 +50,16 @@ public class AddressController {
 	@PutMapping("/{id}")
 	public ResAddressDto updateAddress(
 		@PathVariable UUID id,
-		@Valid @RequestBody ReqUpdateAddressDto requestDto,
-		@AuthenticationPrincipal UserDetailsImpl user
+		@Valid @RequestBody ReqUpdateAddressDto requestDto
 	) {
-		return addressService.updateAddress(id, requestDto, user);
+		return addressService.updateAddress(id, requestDto);
 	}
 
 	@PreAuthorize("@addressPermissionEvaluator.isOwner(#id, authentication.principal)")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<Void> deleteAddress(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl user) {
 		addressService.deleteAddress(id, user);
-		return ResponseEntity.status(HttpStatus.OK).build();
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 }

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -1,17 +1,21 @@
 package com.sparta.delivery.backend.address.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.dto.ReqUpdateAddressDto;
 import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.service.AddressService;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
@@ -38,6 +42,16 @@ public class AddressController {
 	public List<ResAddressDto> getMyAddresses(@AuthenticationPrincipal UserDetailsImpl user) {
 		return addressService.getMyAddresses(user);
 	}
+
+	@PutMapping("/{id}")
+	public ResAddressDto updateAddress(
+		@PathVariable UUID id,
+		@RequestBody ReqUpdateAddressDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl user
+	) {
+		return addressService.updateAddress(id, requestDto, user);
+	}
+
 
 
 }

--- a/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/delivery/backend/address/controller/AddressController.java
@@ -1,14 +1,18 @@
 package com.sparta.delivery.backend.address.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.service.AddressService;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
 
@@ -29,5 +33,11 @@ public class AddressController {
 		addressService.registerAddress(requestDto, user);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
+
+	@GetMapping
+	public List<ResAddressDto> getMyAddresses(@AuthenticationPrincipal UserDetailsImpl user) {
+		return addressService.getMyAddresses(user);
+	}
+
 
 }

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
@@ -1,9 +1,12 @@
 package com.sparta.delivery.backend.address.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@AllArgsConstructor
 public class ReqRegisterAddressDto {
 
 	@NotBlank(message = "법정동 코드는 필수 입력 값입니다.")

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.backend.address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReqRegisterAddressDto {
+
+	@NotBlank(message = "법정동 코드는 필수 입력 값입니다.")
+	private String regionCode;
+
+	@NotBlank(message = "주소는 필수 입력 값입니다.")
+	private String address;
+}

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
@@ -3,7 +3,6 @@ package com.sparta.delivery.backend.address.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqUpdateAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqUpdateAddressDto.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.backend.address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReqUpdateAddressDto {
+
+	@NotBlank(message = "법정동 코드는 필수 입력 값입니다.")
+	private String regionCode;
+
+	@NotBlank(message = "주소는 필수 입력 값입니다.")
+	private String address;
+}

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqUpdateAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqUpdateAddressDto.java
@@ -1,9 +1,11 @@
 package com.sparta.delivery.backend.address.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ReqUpdateAddressDto {
 
 	@NotBlank(message = "법정동 코드는 필수 입력 값입니다.")

--- a/src/main/java/com/sparta/delivery/backend/address/dto/ResAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ResAddressDto.java
@@ -1,0 +1,22 @@
+package com.sparta.delivery.backend.address.dto;
+
+import java.util.UUID;
+
+import com.sparta.delivery.backend.address.entity.Address;
+
+import lombok.Getter;
+
+@Getter
+public class ResAddressDto {
+	private UUID addressId;
+	private String address;
+
+	public ResAddressDto(UUID addressId, String address) {
+		this.addressId = addressId;
+		this.address = address;
+	}
+
+	public static ResAddressDto from(Address address) {
+		return new ResAddressDto(address.getId(), address.getAddress());
+	}
+}

--- a/src/main/java/com/sparta/delivery/backend/address/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/backend/address/entity/Address.java
@@ -40,12 +40,8 @@ public class Address extends BaseEntity {
 	}
 
 	public void update(Dong dong, String address) {
-		if (dong != null) {
-			this.dong = dong;
-		}
-		if (address != null) {
-			this.address = address;
-		}
+		this.dong = dong;
+		this.address = address;
 	}
 
 }

--- a/src/main/java/com/sparta/delivery/backend/address/entity/Address.java
+++ b/src/main/java/com/sparta/delivery/backend/address/entity/Address.java
@@ -1,8 +1,8 @@
 package com.sparta.delivery.backend.address.entity;
 
 import com.sparta.delivery.backend.common.BaseEntity;
-import com.sparta.delivery.backend.customer.entity.Customer;
 import com.sparta.delivery.backend.region.entity.Dong;
+import com.sparta.delivery.backend.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,14 +29,14 @@ public class Address extends BaseEntity {
 	private String address;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "p_customer_id", nullable = false)
-	private Customer customer;
+	@JoinColumn(name = "p_user_id", nullable = false)
+	private User user;
 
 	@Builder
-	private Address(Dong dong, String address, Customer customer) {
+	private Address(Dong dong, String address, User user) {
 		this.dong = dong;
 		this.address = address;
-		this.customer = customer;
+		this.user = user;
 	}
 
 	public void update(Dong dong, String address) {

--- a/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.backend.address.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +10,6 @@ import com.sparta.delivery.backend.address.entity.Address;
 
 public interface AddressRepository extends JpaRepository<Address, UUID> {
 
-	// @Query("select a from Address a join fetch a.user u where u.id = :userId order by a.createdAt desc")
-
-	List<Address> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+	List<Address> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId);
+	Optional<Address> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
@@ -4,12 +4,12 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.delivery.backend.address.entity.Address;
 
 public interface AddressRepository extends JpaRepository<Address, UUID> {
 
-	@Query("select a from Address a join fetch a.customer c join c.user u where u.id = :userId")
-	List<Address> findAllByUserId(Long userId);
+	// @Query("select a from Address a join fetch a.user u where u.id = :userId order by a.createdAt desc")
+
+	List<Address> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/address/repository/AddressRepository.java
@@ -1,10 +1,15 @@
 package com.sparta.delivery.backend.address.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sparta.delivery.backend.address.entity.Address;
 
 public interface AddressRepository extends JpaRepository<Address, UUID> {
+
+	@Query("select a from Address a join fetch a.customer c join c.user u where u.id = :userId")
+	List<Address> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/sparta/delivery/backend/address/security/AddressPermissionEvaluator.java
+++ b/src/main/java/com/sparta/delivery/backend/address/security/AddressPermissionEvaluator.java
@@ -9,9 +9,7 @@ import com.sparta.delivery.backend.address.repository.AddressRepository;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Component("addressPermissionEvaluator")

--- a/src/main/java/com/sparta/delivery/backend/address/security/AddressPermissionEvaluator.java
+++ b/src/main/java/com/sparta/delivery/backend/address/security/AddressPermissionEvaluator.java
@@ -1,0 +1,28 @@
+package com.sparta.delivery.backend.address.security;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.delivery.backend.address.repository.AddressRepository;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Component("addressPermissionEvaluator")
+public class AddressPermissionEvaluator {
+
+	private final AddressRepository addressRepository;
+
+	public boolean isOwner(UUID addressId, UserDetailsImpl user) {
+		return addressRepository.findById(addressId)
+			.map(address -> address.getUser().getId().equals(user.getId()))
+			.orElse(false);
+	}
+
+}

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -11,8 +11,6 @@ import com.sparta.delivery.backend.address.dto.ReqUpdateAddressDto;
 import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.entity.Address;
 import com.sparta.delivery.backend.address.repository.AddressRepository;
-import com.sparta.delivery.backend.customer.entity.Customer;
-import com.sparta.delivery.backend.customer.repository.CustomerRepository;
 import com.sparta.delivery.backend.global.excpetion.NotFoundException;
 import com.sparta.delivery.backend.global.excpetion.UnauthorizedException;
 import com.sparta.delivery.backend.region.entity.Dong;
@@ -46,7 +44,7 @@ public class AddressService {
 
 	@Transactional(readOnly = true)
 	public List<ResAddressDto> getMyAddresses(UserDetailsImpl user) {
-		List<Address> findAddresses = addressRepository.findAllByUserId(user.getId());
+		List<Address> findAddresses = addressRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId());
 		return findAddresses.stream().map(ResAddressDto::from).toList();
 	}
 

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -29,22 +29,17 @@ public class AddressService {
 
 	private final AddressRepository addressRepository;
 	private final DongRepository dongRepository;
-	private final CustomerRepository customerRepository;
 
 	@Transactional
-	public void registerAddress(ReqRegisterAddressDto requestDto, UserDetailsImpl user) {
+	public void registerAddress(ReqRegisterAddressDto requestDto, UserDetailsImpl userDetails) {
 		Dong dong = dongRepository.findByCode(requestDto.getRegionCode()).orElseThrow(
 			() -> new NotFoundException("주소지를 찾을 수 없습니다.")
-		);
-
-		Customer customer = customerRepository.findByUserId(user.getId()).orElseThrow(
-			() -> new NotFoundException("해당 User를 찾을 수 없습니다.")
 		);
 
 		Address address = Address.builder()
 			.dong(dong)
 			.address(requestDto.getAddress())
-			.customer(customer)
+			.user(userDetails.getUser())
 			.build();
 		addressRepository.save(address);
 	}
@@ -61,7 +56,7 @@ public class AddressService {
 			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
 		);
 
-		if (!address.getCustomer().getUser().getId().equals(user.getId())) {
+		if (!address.getUser().getId().equals(user.getId())) {
 			throw new UnauthorizedException("권한이 없습니다.");
 		}
 
@@ -71,5 +66,18 @@ public class AddressService {
 
 		address.update(dong, requestDto.getAddress());
 		return ResAddressDto.from(address);
+	}
+
+	@Transactional
+	public void deleteAddress(UUID id, UserDetailsImpl userDetails) {
+		Address address = addressRepository.findById(id).orElseThrow(
+			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
+		);
+
+		if (!address.getUser().getId().equals(userDetails.getId())) {
+			throw new UnauthorizedException("권한이 없습니다.");
+		}
+
+		address.softDelete(userDetails.getUser().getId());
 	}
 }

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -1,0 +1,45 @@
+package com.sparta.delivery.backend.address.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.entity.Address;
+import com.sparta.delivery.backend.address.repository.AddressRepository;
+import com.sparta.delivery.backend.customer.entity.Customer;
+import com.sparta.delivery.backend.customer.repository.CustomerRepository;
+import com.sparta.delivery.backend.region.entity.Dong;
+import com.sparta.delivery.backend.region.repository.DongRepository;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+
+	private final AddressRepository addressRepository;
+	private final DongRepository dongRepository;
+	private final CustomerRepository customerRepository;
+
+	@Transactional
+	public void registerAddress(ReqRegisterAddressDto requestDto, UserDetailsImpl user) {
+		Dong dong = dongRepository.findByCode(requestDto.getRegionCode()).orElseThrow(
+			() -> new IllegalArgumentException("주소지를 찾을 수 없습니다.")
+		);
+
+		Customer customer = customerRepository.findByUserId(user.getId()).orElseThrow(
+			() -> new IllegalArgumentException("해당 User를 찾을 수 없습니다.")
+		);
+
+		Address address = Address.builder()
+			.dong(dong)
+			.address(requestDto.getAddress())
+			.customer(customer)
+			.build();
+
+		addressRepository.save(address);
+	}
+}

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -1,17 +1,20 @@
 package com.sparta.delivery.backend.address.service;
 
 import java.util.List;
+import java.util.UUID;
 
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.dto.ReqUpdateAddressDto;
 import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.entity.Address;
 import com.sparta.delivery.backend.address.repository.AddressRepository;
 import com.sparta.delivery.backend.customer.entity.Customer;
 import com.sparta.delivery.backend.customer.repository.CustomerRepository;
+import com.sparta.delivery.backend.global.excpetion.NotFoundException;
+import com.sparta.delivery.backend.global.excpetion.UnauthorizedException;
 import com.sparta.delivery.backend.region.entity.Dong;
 import com.sparta.delivery.backend.region.repository.DongRepository;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
@@ -31,11 +34,11 @@ public class AddressService {
 	@Transactional
 	public void registerAddress(ReqRegisterAddressDto requestDto, UserDetailsImpl user) {
 		Dong dong = dongRepository.findByCode(requestDto.getRegionCode()).orElseThrow(
-			() -> new IllegalArgumentException("주소지를 찾을 수 없습니다.")
+			() -> new NotFoundException("주소지를 찾을 수 없습니다.")
 		);
 
 		Customer customer = customerRepository.findByUserId(user.getId()).orElseThrow(
-			() -> new IllegalArgumentException("해당 User를 찾을 수 없습니다.")
+			() -> new NotFoundException("해당 User를 찾을 수 없습니다.")
 		);
 
 		Address address = Address.builder()
@@ -50,5 +53,23 @@ public class AddressService {
 	public List<ResAddressDto> getMyAddresses(UserDetailsImpl user) {
 		List<Address> findAddresses = addressRepository.findAllByUserId(user.getId());
 		return findAddresses.stream().map(ResAddressDto::from).toList();
+	}
+
+	@Transactional
+	public ResAddressDto updateAddress(UUID id, ReqUpdateAddressDto requestDto, UserDetailsImpl user) {
+		Address address = addressRepository.findById(id).orElseThrow(
+			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
+		);
+
+		if (!address.getCustomer().getUser().getId().equals(user.getId())) {
+			throw new UnauthorizedException("권한이 없습니다.");
+		}
+
+		Dong dong = dongRepository.findByCode(requestDto.getRegionCode()).orElseThrow(
+			() -> new NotFoundException("해당 주소지를 찾을 수 없습니다.")
+		);
+
+		address.update(dong, requestDto.getAddress());
+		return ResAddressDto.from(address);
 	}
 }

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -17,9 +17,7 @@ import com.sparta.delivery.backend.region.repository.DongRepository;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AddressService {
@@ -49,8 +47,8 @@ public class AddressService {
 	}
 
 	@Transactional
-	public ResAddressDto updateAddress(UUID id, ReqUpdateAddressDto requestDto, UserDetailsImpl user) {
-		Address address = addressRepository.findById(id).orElseThrow(
+	public ResAddressDto updateAddress(UUID id, ReqUpdateAddressDto requestDto) {
+		Address address = addressRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
 			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
 		);
 

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -12,7 +12,6 @@ import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.entity.Address;
 import com.sparta.delivery.backend.address.repository.AddressRepository;
 import com.sparta.delivery.backend.global.excpetion.NotFoundException;
-import com.sparta.delivery.backend.global.excpetion.UnauthorizedException;
 import com.sparta.delivery.backend.region.entity.Dong;
 import com.sparta.delivery.backend.region.repository.DongRepository;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
@@ -44,7 +43,8 @@ public class AddressService {
 
 	@Transactional(readOnly = true)
 	public List<ResAddressDto> getMyAddresses(UserDetailsImpl user) {
-		List<Address> findAddresses = addressRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId());
+		List<Address> findAddresses = addressRepository.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+			user.getId());
 		return findAddresses.stream().map(ResAddressDto::from).toList();
 	}
 
@@ -53,10 +53,6 @@ public class AddressService {
 		Address address = addressRepository.findById(id).orElseThrow(
 			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
 		);
-
-		if (!address.getUser().getId().equals(user.getId())) {
-			throw new UnauthorizedException("권한이 없습니다.");
-		}
 
 		Dong dong = dongRepository.findByCode(requestDto.getRegionCode()).orElseThrow(
 			() -> new NotFoundException("해당 주소지를 찾을 수 없습니다.")
@@ -68,13 +64,9 @@ public class AddressService {
 
 	@Transactional
 	public void deleteAddress(UUID id, UserDetailsImpl userDetails) {
-		Address address = addressRepository.findById(id).orElseThrow(
+		Address address = addressRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
 			() -> new NotFoundException("요청한 리소스를 찾을 수 없습니다.")
 		);
-
-		if (!address.getUser().getId().equals(userDetails.getId())) {
-			throw new UnauthorizedException("권한이 없습니다.");
-		}
 
 		address.softDelete(userDetails.getUser().getId());
 	}

--- a/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
+++ b/src/main/java/com/sparta/delivery/backend/address/service/AddressService.java
@@ -1,9 +1,13 @@
 package com.sparta.delivery.backend.address.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.dto.ResAddressDto;
 import com.sparta.delivery.backend.address.entity.Address;
 import com.sparta.delivery.backend.address.repository.AddressRepository;
 import com.sparta.delivery.backend.customer.entity.Customer;
@@ -39,7 +43,12 @@ public class AddressService {
 			.address(requestDto.getAddress())
 			.customer(customer)
 			.build();
-
 		addressRepository.save(address);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ResAddressDto> getMyAddresses(UserDetailsImpl user) {
+		List<Address> findAddresses = addressRepository.findAllByUserId(user.getId());
+		return findAddresses.stream().map(ResAddressDto::from).toList();
 	}
 }

--- a/src/main/java/com/sparta/delivery/backend/global/excpetion/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/backend/global/excpetion/GlobalExceptionHandler.java
@@ -28,6 +28,15 @@ public class GlobalExceptionHandler {
 		);
 	}
 
+	@ExceptionHandler({NotFoundException.class})
+	public ResponseEntity<ApiException> handleException(NotFoundException ex) {
+		ApiException apiException = new ApiException(ex.getMessage(), HttpStatus.NOT_FOUND.value());
+		return new ResponseEntity<>(
+			apiException,
+			HttpStatus.NOT_FOUND
+		);
+	}
+
 	@ExceptionHandler({HttpMessageNotReadableException.class})
 	public ResponseEntity<ApiException> handleException(HttpMessageNotReadableException ex) {
 		ApiException apiException = new ApiException("잘못된 JSON 형식입니다.", HttpStatus.BAD_REQUEST.value());

--- a/src/main/java/com/sparta/delivery/backend/global/excpetion/NotFoundException.java
+++ b/src/main/java/com/sparta/delivery/backend/global/excpetion/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.backend.global.excpetion;
+
+public class NotFoundException extends RuntimeException {
+	public NotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sparta/delivery/backend/region/repository/DongRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/region/repository/DongRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.backend.region.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.sparta.delivery.backend.region.entity.Dong;
 
 public interface DongRepository extends JpaRepository<Dong, UUID> {
+	Optional<Dong> findByCode(String code);
 }

--- a/src/test/java/com/sparta/delivery/backend/address/repository/AddressRepositoryTest.java
+++ b/src/test/java/com/sparta/delivery/backend/address/repository/AddressRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.backend.address.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AddressRepositoryTest {
+
+}

--- a/src/test/java/com/sparta/delivery/backend/address/repository/AddressRepositoryTest.java
+++ b/src/test/java/com/sparta/delivery/backend/address/repository/AddressRepositoryTest.java
@@ -1,7 +1,320 @@
 package com.sparta.delivery.backend.address.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.delivery.backend.address.entity.Address;
+import com.sparta.delivery.backend.region.entity.Dong;
+import com.sparta.delivery.backend.region.entity.Sido;
+import com.sparta.delivery.backend.region.entity.Sigungu;
+import com.sparta.delivery.backend.user.entity.User;
+import com.sparta.delivery.backend.user.entity.UserRoleEnum;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("AddressRepository 테스트")
 class AddressRepositoryTest {
 
+	@Autowired
+	private AddressRepository addressRepository;
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	private User testUser;
+	private User otherUser;
+	private Dong testDong;
+	private Dong otherDong;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 사용자 생성
+		testUser = User.builder()
+			.username("testUser")
+			.password("password123")
+			.role(UserRoleEnum.CUSTOMER)
+			.build();
+		entityManager.persist(testUser);
+
+		otherUser = User.builder()
+			.username("otherUser")
+			.password("password456")
+			.role(UserRoleEnum.CUSTOMER)
+			.build();
+		entityManager.persist(otherUser);
+
+		Sido seoul = createSido("서울특별시", "11");
+		entityManager.persist(seoul);
+
+		Sigungu gangnam = createSigungu(seoul, "강남구", "680");
+		entityManager.persist(gangnam);
+
+		Sigungu seocho = createSigungu(seoul, "서초구", "650");
+		entityManager.persist(seocho);
+
+		testDong = createDong(gangnam,"102","역삼동");
+		entityManager.persist(testDong);
+
+		otherDong = createDong(seocho,"103","서초동");
+		entityManager.persist(otherDong);
+
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+	@Nested
+	@DisplayName("findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc 메서드는")
+	class FindAllByUserIdTest {
+
+		@Test
+		@DisplayName("삭제되지 않은 주소들을 생성일 역순으로 조회한다")
+		void success_findAllActiveAddressesOrderByCreatedAtDesc() {
+			// given
+			Address address1 = createAddress(testUser, testDong, "강남구 테헤란로 1");
+			entityManager.persist(address1);
+			entityManager.flush();
+
+			sleep();
+
+			Address address2 = createAddress(testUser, testDong, "강남구 테헤란로 2");
+			entityManager.persist(address2);
+			entityManager.flush();
+
+			sleep();
+
+			Address address3 = createAddress(testUser, testDong, "강남구 테헤란로 3");
+			entityManager.persist(address3);
+			entityManager.flush();
+			entityManager.clear();
+
+			// when
+			List<Address> addresses = addressRepository
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(testUser.getId());
+
+			// then
+			assertThat(addresses).hasSize(3);
+			assertThat(addresses.get(0).getAddress()).isEqualTo("강남구 테헤란로 3");
+			assertThat(addresses.get(1).getAddress()).isEqualTo("강남구 테헤란로 2");
+			assertThat(addresses.get(2).getAddress()).isEqualTo("강남구 테헤란로 1");
+
+			// 생성 시간 순서 확인
+			assertThat(addresses.get(0).getCreatedAt())
+				.isAfterOrEqualTo(addresses.get(1).getCreatedAt());
+			assertThat(addresses.get(1).getCreatedAt())
+				.isAfterOrEqualTo(addresses.get(2).getCreatedAt());
+		}
+
+		@Test
+		@DisplayName("삭제된 주소는 조회 결과에서 제외된다")
+		void success_excludeDeletedAddresses() {
+			// given
+			Address activeAddress = createAddress(testUser, testDong, "활성 주소");
+			entityManager.persist(activeAddress);
+
+			Address deletedAddress = createAddress(testUser, testDong, "삭제된 주소");
+			entityManager.persist(deletedAddress);
+			entityManager.flush();
+
+			// 주소 소프트 삭제
+			deletedAddress.softDelete(testUser.getId());
+			entityManager.flush();
+			entityManager.clear();
+
+			// when
+			List<Address> addresses = addressRepository
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(testUser.getId());
+
+			// then
+			assertThat(addresses).hasSize(1);
+			assertThat(addresses.get(0).getAddress()).isEqualTo("활성 주소");
+			assertThat(addresses.get(0).isDeleted()).isFalse();
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 주소는 조회되지 않는다")
+		void success_excludeOtherUsersAddresses() {
+			// given
+			Address myAddress1 = createAddress(testUser, testDong, "내 주소 1");
+			Address myAddress2 = createAddress(testUser, testDong, "내 주소 2");
+			Address othersAddress = createAddress(otherUser, otherDong, "다른 사람 주소");
+
+			entityManager.persist(myAddress1);
+			entityManager.persist(myAddress2);
+			entityManager.persist(othersAddress);
+			entityManager.flush();
+			entityManager.clear();
+
+			// when
+			List<Address> addresses = addressRepository
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(testUser.getId());
+
+			// then
+			assertThat(addresses).hasSize(2);
+			assertThat(addresses)
+				.extracting(Address::getAddress)
+				.containsExactlyInAnyOrder("내 주소 1", "내 주소 2")
+				.doesNotContain("다른 사람 주소");
+		}
+
+		@Test
+		@DisplayName("주소가 하나도 없으면 빈 리스트를 반환한다")
+		void success_returnEmptyListWhenNoAddresses() {
+			// when
+			List<Address> addresses = addressRepository
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(testUser.getId());
+
+			// then
+			assertThat(addresses).isEmpty();
+		}
+
+		@Test
+		@DisplayName("모든 주소가 삭제된 경우 빈 리스트를 반환한다")
+		void success_returnEmptyListWhenAllAddressesDeleted() {
+			// given
+			Address address1 = createAddress(testUser, testDong, "주소 1");
+			Address address2 = createAddress(testUser, testDong, "주소 2");
+			entityManager.persist(address1);
+			entityManager.persist(address2);
+			entityManager.flush();
+
+			address1.softDelete(testUser.getId());
+			address2.softDelete(testUser.getId());
+			entityManager.flush();
+			entityManager.clear();
+
+			// when
+			List<Address> addresses = addressRepository
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(testUser.getId());
+
+			// then
+			assertThat(addresses).isEmpty();
+		}
+	}
+
+	@Nested
+	@DisplayName("findByIdAndDeletedAtIsNull 메서드는")
+	class FindByIdTest {
+
+		@Test
+		@DisplayName("삭제되지 않은 주소를 ID로 조회한다")
+		void success_findActiveAddressById() {
+			// given
+			Address address = createAddress(testUser, testDong, "서울시 강남구 역삼동 123");
+			entityManager.persist(address);
+			entityManager.flush();
+			entityManager.clear();
+
+			UUID addressId = address.getId();
+
+			// when
+			Optional<Address> foundAddress = addressRepository
+				.findByIdAndDeletedAtIsNull(addressId);
+
+			// then
+			assertThat(foundAddress).isPresent();
+			assertThat(foundAddress.get().getId()).isEqualTo(addressId);
+			assertThat(foundAddress.get().getAddress()).isEqualTo("서울시 강남구 역삼동 123");
+			assertThat(foundAddress.get().isDeleted()).isFalse();
+			assertThat(foundAddress.get().getDeletedAt()).isNull();
+			assertThat(foundAddress.get().getUser().getId()).isEqualTo(testUser.getId());
+			assertThat(foundAddress.get().getDong().getId()).isEqualTo(testDong.getId());
+		}
+
+		@Test
+		@DisplayName("삭제된 주소는 조회되지 않는다")
+		void fail_notFindDeletedAddress() {
+			// given
+			Address address = createAddress(testUser, testDong, "삭제될 주소");
+			entityManager.persist(address);
+			entityManager.flush();
+
+			UUID addressId = address.getId();
+			address.softDelete(testUser.getId());
+			entityManager.flush();
+			entityManager.clear();
+
+			// when
+			Optional<Address> foundAddress = addressRepository
+				.findByIdAndDeletedAtIsNull(addressId);
+
+			// then
+			assertThat(foundAddress).isEmpty();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 ID로 조회하면 빈 Optional을 반환한다")
+		void fail_returnEmptyForNonExistentId() {
+			// given
+			UUID nonExistentId = UUID.randomUUID();
+
+			// when
+			Optional<Address> foundAddress = addressRepository
+				.findByIdAndDeletedAtIsNull(nonExistentId);
+
+			// then
+			assertThat(foundAddress).isEmpty();
+		}
+
+		@Test
+		@DisplayName("null ID로 조회하면 빈 Optional을 반환한다")
+		void fail_returnEmptyForNullId() {
+			// when
+			Optional<Address> foundAddress = addressRepository
+				.findByIdAndDeletedAtIsNull(null);
+
+			// then
+			assertThat(foundAddress).isEmpty();
+		}
+	}
+
+	private Address createAddress(User user, Dong dong, String address) {
+		return Address.builder()
+			.user(user)
+			.dong(dong)
+			.address(address)
+			.build();
+	}
+
+	private Sido createSido(String name, String code) {
+		return Sido.builder()
+			.name(name)
+			.code(code)
+			.build();
+	}
+
+	private Sigungu createSigungu(Sido sido, String name, String code) {
+		return Sigungu.builder()
+			.sido(sido)
+			.name(name)
+			.code(code)
+			.build();
+	}
+
+	private Dong createDong(Sigungu sigungu, String code, String name) {
+		return Dong.builder()
+			.sigungu(sigungu)
+			.code(code)
+			.name(name)
+			.build();
+	}
+
+	private void sleep() {
+		try {
+			Thread.sleep((long)10);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
 }

--- a/src/test/java/com/sparta/delivery/backend/address/service/AddressServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/address/service/AddressServiceTest.java
@@ -1,0 +1,247 @@
+package com.sparta.delivery.backend.address.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sparta.delivery.backend.address.dto.ReqRegisterAddressDto;
+import com.sparta.delivery.backend.address.dto.ReqUpdateAddressDto;
+import com.sparta.delivery.backend.address.dto.ResAddressDto;
+import com.sparta.delivery.backend.address.entity.Address;
+import com.sparta.delivery.backend.address.repository.AddressRepository;
+import com.sparta.delivery.backend.global.excpetion.NotFoundException;
+import com.sparta.delivery.backend.region.entity.Dong;
+import com.sparta.delivery.backend.region.repository.DongRepository;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
+import com.sparta.delivery.backend.user.entity.User;
+import com.sparta.delivery.backend.user.entity.UserRoleEnum;
+
+@ExtendWith(MockitoExtension.class)
+class AddressServiceTest {
+
+	@Mock
+	private AddressRepository addressRepository;
+
+	@Mock
+	private DongRepository dongRepository;
+
+	@InjectMocks
+	private AddressService addressService;
+
+	private User user;
+	private UserDetailsImpl userDetails;
+	private Dong dong;
+	private Address address;
+
+	@BeforeEach
+	void setUp() {
+		user = User.builder()
+			.username("test")
+			.password("password")
+			.role(UserRoleEnum.CUSTOMER)
+			.build();
+
+		userDetails = new UserDetailsImpl(user);
+
+		dong = Dong.builder()
+			.code("123")
+			.name("망원1동")
+			.build();
+
+		address = Address.builder()
+			.dong(dong)
+			.address("서울특별시 마포구 망원1동 마포나루길 467")
+			.user(user)
+			.build();
+	}
+
+	@Nested
+	@DisplayName("주소 등록 테스트")
+	class RegisterAddressTest {
+
+		@Test
+		@DisplayName("성공")
+		void registerAddress_Success() {
+			ReqRegisterAddressDto requestDto = new ReqRegisterAddressDto(
+				"123",
+				"서울특별시 마포구 망원1동 마포나루길 467");
+
+			given(dongRepository.findByCode(requestDto.getRegionCode()))
+				.willReturn(Optional.of(dong));
+
+			given(addressRepository.save(any(Address.class)))
+				.willReturn(address);
+
+			addressService.registerAddress(requestDto, userDetails);
+
+			then(dongRepository).should(times(1)).findByCode(requestDto.getRegionCode());
+			then(addressRepository).should(times(1)).save(any(Address.class));
+		}
+
+		@Test
+		@DisplayName("실패 - 존재하지 않는 지역 코드")
+		void registerAddress_Fail_DongNotFound() {
+			ReqRegisterAddressDto requestDto = new ReqRegisterAddressDto(
+				"999",
+				"서울특별시 마포구 망원1동 마포나루길 467");
+
+			given(dongRepository.findByCode(requestDto.getRegionCode()))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> addressService.registerAddress(requestDto, userDetails))
+				.isInstanceOf(NotFoundException.class)
+				.hasMessage("주소지를 찾을 수 없습니다.");
+
+			then(addressRepository).should(never()).save(any(Address.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("내 주소 목록 조회 테스트")
+	class GetMyAddressesTest {
+
+		@Test
+		@DisplayName("성공")
+		void getMyAddresses_Success() {
+			Address anotherAddress = Address.builder()
+				.dong(dong)
+				.address("강남대로 456")
+				.user(user)
+				.build();
+
+			List<Address> addresses = List.of(address, anotherAddress);
+
+			given(addressRepository.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(user.getId()))
+				.willReturn(addresses);
+
+			List<ResAddressDto> result = addressService.getMyAddresses(userDetails);
+
+			assertThat(result).hasSize(2);
+			then(addressRepository).should(times(1))
+				.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(user.getId());
+		}
+	}
+
+	@Nested
+	@DisplayName("주소 수정 테스트")
+	class UpdateAddressTest {
+
+		@Test
+		@DisplayName("성공")
+		void updateAddress_Success() {
+			UUID addressId = address.getId();
+			ReqUpdateAddressDto requestDto = new ReqUpdateAddressDto(
+				"136",
+				"새로운 주소 789"
+			);
+
+			given(addressRepository.findById(addressId))
+				.willReturn(Optional.of(address));
+
+			given(dongRepository.findByCode(requestDto.getRegionCode()))
+				.willReturn(Optional.of(dong));
+
+			ResAddressDto result = addressService.updateAddress(addressId, requestDto, userDetails);
+
+			assertThat(result).isNotNull();
+			then(addressRepository).should(times(1)).findById(addressId);
+			then(dongRepository).should(times(1)).findByCode(requestDto.getRegionCode());
+		}
+
+		@Test
+		@DisplayName("실패 - 존재하지 않는 주소 ID")
+		void updateAddress_Fail_AddressNotFound() {
+			UUID addressId = UUID.randomUUID();
+			ReqUpdateAddressDto requestDto = new ReqUpdateAddressDto(
+				"123",
+				"새로운 주소 789"
+			);
+
+			given(addressRepository.findById(addressId))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto, userDetails))
+				.isInstanceOf(NotFoundException.class)
+				.hasMessage("요청한 리소스를 찾을 수 없습니다.");
+
+			then(dongRepository).should(never()).findByCode(anyString());
+		}
+
+		@Test
+		@DisplayName("주소 수정: 실패 - 존재하지 않는 지역 코드")
+		void updateAddress_Fail_RegionDongNotFound() {
+			UUID addressId = address.getId();
+			ReqUpdateAddressDto requestDto = new ReqUpdateAddressDto(
+				"999",
+				"새로운 주소 789"
+			);
+
+			given(addressRepository.findById(addressId))
+				.willReturn(Optional.of(address));
+
+			given(dongRepository.findByCode(requestDto.getRegionCode()))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto, userDetails))
+				.isInstanceOf(NotFoundException.class)
+				.hasMessage("해당 주소지를 찾을 수 없습니다.");
+		}
+	}
+
+	@Nested
+	@DisplayName("주소 삭제 테스트")
+	class DeleteAddressTest {
+
+		@Test
+		@DisplayName("주소 삭제: 성공")
+		void deleteAddress_Success() {
+			UUID addressId = address.getId();
+
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
+				.willReturn(Optional.of(address));
+
+			addressService.deleteAddress(addressId, userDetails);
+
+			then(addressRepository).should(times(1)).findByIdAndDeletedAtIsNull(addressId);
+		}
+
+		@Test
+		@DisplayName("주소 삭제: 실패 - 존재하지 않는 주소 ID")
+		void deleteAddress_Fail_AddressNotFound() {
+			UUID addressId = UUID.randomUUID();
+
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> addressService.deleteAddress(addressId, userDetails))
+				.isInstanceOf(NotFoundException.class)
+				.hasMessage("요청한 리소스를 찾을 수 없습니다.");
+		}
+
+		@Test
+		@DisplayName("주소 삭제: 실패 - 이미 삭제된 주소")
+		void deleteAddress_Fail_AlreadyDeleted() {
+			UUID addressId = address.getId();
+
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
+				.willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> addressService.deleteAddress(addressId, userDetails))
+				.isInstanceOf(NotFoundException.class)
+				.hasMessage("요청한 리소스를 찾을 수 없습니다.");
+		}
+	}
+}

--- a/src/test/java/com/sparta/delivery/backend/address/service/AddressServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/address/service/AddressServiceTest.java
@@ -148,16 +148,16 @@ class AddressServiceTest {
 				"새로운 주소 789"
 			);
 
-			given(addressRepository.findById(addressId))
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
 				.willReturn(Optional.of(address));
 
 			given(dongRepository.findByCode(requestDto.getRegionCode()))
 				.willReturn(Optional.of(dong));
 
-			ResAddressDto result = addressService.updateAddress(addressId, requestDto, userDetails);
+			ResAddressDto result = addressService.updateAddress(addressId, requestDto);
 
 			assertThat(result).isNotNull();
-			then(addressRepository).should(times(1)).findById(addressId);
+			then(addressRepository).should(times(1)).findByIdAndDeletedAtIsNull(addressId);
 			then(dongRepository).should(times(1)).findByCode(requestDto.getRegionCode());
 		}
 
@@ -170,10 +170,10 @@ class AddressServiceTest {
 				"새로운 주소 789"
 			);
 
-			given(addressRepository.findById(addressId))
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
 				.willReturn(Optional.empty());
 
-			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto, userDetails))
+			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto))
 				.isInstanceOf(NotFoundException.class)
 				.hasMessage("요청한 리소스를 찾을 수 없습니다.");
 
@@ -189,13 +189,13 @@ class AddressServiceTest {
 				"새로운 주소 789"
 			);
 
-			given(addressRepository.findById(addressId))
+			given(addressRepository.findByIdAndDeletedAtIsNull(addressId))
 				.willReturn(Optional.of(address));
 
 			given(dongRepository.findByCode(requestDto.getRegionCode()))
 				.willReturn(Optional.empty());
 
-			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto, userDetails))
+			assertThatThrownBy(() -> addressService.updateAddress(addressId, requestDto))
 				.isInstanceOf(NotFoundException.class)
 				.hasMessage("해당 주소지를 찾을 수 없습니다.");
 		}


### PR DESCRIPTION
## 📌 개요
- 배송지 주소 CRUD API 및 Service, Repository 테스트 추가

## 🔨 변경 사항
- Address Entity 연관관계 Customer → User 로 변경
- 배송지 주소 등록 API
- 배송지 주소 조회(List) API
- 배송지 주소 업데이트 API
- 배송지 주소 삭제(softDelete) API
- Adress Service, Repository Test 추가

## ✅ 테스트
- [x] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
X