### PR TITLE
Feat/add ai api

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.backend.ai.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +31,7 @@ public class AiPromptController {
 	public ResponseEntity<ResCreateAiPromptDto> createAiPrompt(@Valid @RequestBody ReqCreateAiPromptDto requestDto) {
 		ResCreateAiPromptDto responseDto = aiPromptService.createAiPrompt(requestDto);
 
-		return ResponseEntity.ok(responseDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 	}
 
 	@GetMapping

--- a/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
@@ -26,7 +26,7 @@ public class AiPromptController {
 	private final AiPromptService aiPromptService;
 
 	@PostMapping
-	@PreAuthorize("isAuthenticated() && hasRole('OWNER')")
+	@PreAuthorize("isAuthenticated() && hasAnyRole('MANAGER', 'OWNER')")
 	public ResponseEntity<ResCreateAiPromptDto> createAiPrompt(@Valid @RequestBody ReqCreateAiPromptDto requestDto) {
 		ResCreateAiPromptDto responseDto = aiPromptService.createAiPrompt(requestDto);
 

--- a/src/test/java/com/sparta/delivery/backend/ai/service/AiPromptServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/ai/service/AiPromptServiceTest.java
@@ -58,19 +58,6 @@ public class AiPromptServiceTest {
 			then(aiPromptRepository).should(times(1)).save(any(AiPrompt.class));
 		}
 
-		@Test
-		@DisplayName("실패")
-		void failure() {
-			ReqCreateAiPromptDto requestDto = new ReqCreateAiPromptDto("요청");
-
-			given(googleAiService.createAiPrompt("요청")).willThrow(new RuntimeException("오류"));
-
-			assertThatThrownBy(() -> aiPromptService.createAiPrompt(requestDto))
-				.isInstanceOf(RuntimeException.class)
-				.hasMessage("오류");
-			then(aiPromptRepository).should(never()).save(any(AiPrompt.class));
-		}
-
 	}
 
 	@Nested


### PR DESCRIPTION
## 📌 개요
- ai api 일부 수정

## 🔨 변경 사항
- 매니저도 ai 프롬프트를 생성할 수 있도록 컨트롤러에 권한 추가
- 컨트롤러 createAiPrompt 메서드 응답 상태 코드 200 -> 201로 변경
- ai 프롬프트 생성 테스트 코드에서 실패 테스트가 의미가 없다고 판단되어 삭제 (외부 api 사용 테스트가 목적이었는데, 예외를 던진 후 GoogleAiService의 createAiPrompt 메서드를 호출할 때 예외를 던지므로 try-catch 문을 통과하지 않게 되어 의미가 없음)

## ✅ 테스트
- [x] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?