### PR TITLE
feat(owner): 점주 관련 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/delivery/backend/auth/service/AuthService.java
@@ -49,7 +49,7 @@ public class AuthService {
 		String username = claims.getSubject();
 
 		// User 조회
-		User user = userRepository.findByUsername(username)
+		User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
 			.orElseThrow(() -> new RuntimeException("User not found"));
 
 		// 새 토큰 발급 (Rotation)

--- a/src/main/java/com/sparta/delivery/backend/customer/dto/ReqCreateCustomerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/customer/dto/ReqCreateCustomerDto.java
@@ -1,7 +1,7 @@
 package com.sparta.delivery.backend.customer.dto;
 
-import com.sparta.delivery.backend.global.annotation.validate.ValidPassword;
-import com.sparta.delivery.backend.global.annotation.validate.ValidUsername;
+import com.sparta.delivery.backend.global.validation.annotation.ValidPassword;
+import com.sparta.delivery.backend.global.validation.annotation.ValidUsername;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Schema(description = "고객 회원가입 요청")
+@Schema(name = "ReqCreateCustomerDto", description = "고객 회원가입 요청")
 public class ReqCreateCustomerDto {
 
 	@Schema(description = "사용자 아이디", example = "customer1", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/sparta/delivery/backend/customer/service/CustomerService.java
+++ b/src/main/java/com/sparta/delivery/backend/customer/service/CustomerService.java
@@ -46,7 +46,7 @@ public class CustomerService {
 	@Transactional
 	public void createCustomer(ReqCreateCustomerDto requestDto) {
 		//같은 메일로 다른 사용자 요청 가능하도록 할지 정책 결정필요
-		userRepository.findByUsername(requestDto.getUsername())
+		userRepository.findByUsernameAndDeletedAtIsNull(requestDto.getUsername())
 			.ifPresent(user -> {
 				throw new DuplicateUsernameException("이미 존재하는 사용자명입니다.");
 			});
@@ -89,7 +89,7 @@ public class CustomerService {
 
 	@Transactional
 	public void changePassword(UserDetailsImpl userDetails, @Valid ReqChangePasswordDto requestDto) {
-		User user = userRepository.findById(userDetails.getId())
+		User user = userRepository.findByIdAndDeletedAtIsNull(userDetails.getId())
 			.orElseThrow(() -> new IllegalArgumentException("잘못된 유저 아이디 입니다."));
 
 		if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {

--- a/src/main/java/com/sparta/delivery/backend/global/validation/annotation/ValidPassword.java
+++ b/src/main/java/com/sparta/delivery/backend/global/validation/annotation/ValidPassword.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.backend.global.annotation.validate;
+package com.sparta.delivery.backend.global.validation.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/sparta/delivery/backend/global/validation/annotation/ValidUsername.java
+++ b/src/main/java/com/sparta/delivery/backend/global/validation/annotation/ValidUsername.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.backend.global.annotation.validate;
+package com.sparta.delivery.backend.global.validation.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/sparta/delivery/backend/manager/dto/ReqCreateManagerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/manager/dto/ReqCreateManagerDto.java
@@ -1,8 +1,9 @@
 package com.sparta.delivery.backend.manager.dto;
 
-import com.sparta.delivery.backend.global.annotation.validate.ValidPassword;
-import com.sparta.delivery.backend.global.annotation.validate.ValidUsername;
+import com.sparta.delivery.backend.global.validation.annotation.ValidPassword;
+import com.sparta.delivery.backend.global.validation.annotation.ValidUsername;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -11,25 +12,32 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(name = "ReqCreateManagerDto", description = "매니저 회원가입 요청")
 public class ReqCreateManagerDto {
 
+	@Schema(description = "사용자 아이디", example = "manager1")
 	@ValidUsername
 	private String username;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@ValidPassword
 	private String password;
 
+	@Schema(description = "이메일", example = "manager@example.com")
 	@NotBlank(message = "이메일은 필수입니다.")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	@Size(max = 320, message = "이메일은 최대 320자까지 가능합니다.")
 	private String email;
 
+	@Schema(description = "매니저 이름", example = "김매니저")
 	@NotBlank(message = "매니저 이름은 필수입니다.")
 	private String name;
 
+	@Schema(description = "전화번호", example = "010-1234-5678")
 	@Size(max = 20, message = "전화번호는 최대 20자까지 가능합니다.")
 	private String phoneNumber;
 
+	@Schema(description = "이메일 인증 토큰", example = "550e8400-e29b-41d4-a716-446655440000")
 	@NotBlank(message = "이메일 인증 토큰은 필수입니다.")
 	private String emailVerificationToken;
 }

--- a/src/main/java/com/sparta/delivery/backend/manager/service/ManagerService.java
+++ b/src/main/java/com/sparta/delivery/backend/manager/service/ManagerService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.delivery.backend.global.excpetion.DuplicateUsernameException;
-import com.sparta.delivery.backend.global.verification.EmailVerificationTokenValidator;
 import com.sparta.delivery.backend.manager.dto.ReqCreateManagerDto;
 import com.sparta.delivery.backend.manager.entity.Manager;
 import com.sparta.delivery.backend.manager.repository.ManagerRepository;
@@ -26,7 +25,7 @@ public class ManagerService {
 	@Transactional
 	public void createManager(ReqCreateManagerDto requestDto) {
 		//같은 메일로 다른 사용자 요청 가능하도록 할지 정책 결정필요
-		userRepository.findByUsername(requestDto.getUsername())
+		userRepository.findByUsernameAndDeletedAtIsNull(requestDto.getUsername())
 			.ifPresent(user -> {
 				throw new DuplicateUsernameException("이미 존재하는 사용자명입니다.");
 			});

--- a/src/main/java/com/sparta/delivery/backend/owner/controller/OwnerController.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/controller/OwnerController.java
@@ -1,30 +1,168 @@
 package com.sparta.delivery.backend.owner.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sparta.delivery.backend.owner.dto.ReqChangePasswordDto;
 import com.sparta.delivery.backend.owner.dto.ReqCreateOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ReqPasswordResetDto;
+import com.sparta.delivery.backend.owner.dto.ReqPasswordResetRequestDto;
+import com.sparta.delivery.backend.owner.dto.ReqUpdateOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ResGetMyOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ResGetOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ResPasswordResetRequestDto;
 import com.sparta.delivery.backend.owner.service.OwnerService;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
+import com.sparta.delivery.backend.user.entity.UserRoleEnum;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestController
 @RequestMapping("/v1/owners")
 @RequiredArgsConstructor
+@Tag(name = "점주 API V1", description = "점주 관련 API")
 public class OwnerController {
 
-	private final OwnerService ownerService;
+    private final OwnerService ownerService;
 
-	@PostMapping
-	public ResponseEntity<Void> createOwner(@Valid @RequestBody ReqCreateOwnerDto requestDto) {
-		ownerService.createOwner(requestDto);
-		return ResponseEntity.status(HttpStatus.CREATED).build();
-	}
+    @Operation(summary = "점주 회원가입", description = "새로운 점주를 등록합니다")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "409", description = "이미 존재하는 사용자")
+    })
+    @PostMapping
+    public ResponseEntity<Void> createOwner(@Valid @RequestBody ReqCreateOwnerDto requestDto) {
+       ownerService.createOwner(requestDto);
+       return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 점주의 마이페이지 정보를 조회합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "점주 정보를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.OWNER)
+    @GetMapping("/me")
+    public ResponseEntity<ResGetMyOwnerDto> getCurrentOwner(
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ResGetMyOwnerDto response = ownerService.getCurrentOwner(userDetails);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "점주 정보 조회 (관리자용)", description = "관리자가 특정 점주의 정보를 조회합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "점주 정보를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.MANAGER)
+    @GetMapping("/{ownerUserPublicId}")
+    public ResponseEntity<ResGetOwnerDto> getOwnerByUserPublicId(@PathVariable UUID ownerUserPublicId) {
+        ResGetOwnerDto response = ownerService.getOwnerByUserPublicId(ownerUserPublicId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 정보 수정", description = "로그인한 점주의 정보를 수정합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "점주 정보를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.OWNER)
+    @PatchMapping("/me")
+    public ResponseEntity<Void> updateCurrentOwner(
+        @AuthenticationPrincipal UserDetailsImpl userDetails, 
+        @Valid @RequestBody ReqUpdateOwnerDto requestDto) {
+        ownerService.updateCurrentOwner(userDetails, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "로그인한 상태에서 비밀번호를 변경합니다 (기존 비밀번호 필요)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "점주 정보를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.OWNER)
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePassword(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Valid @RequestBody ReqChangePasswordDto requestDto) {
+        ownerService.changePassword(userDetails, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 재설정 요청", description = "이메일로 비밀번호 재설정 링크를 발송합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청이 처리되었습니다"),
+    })
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<ResPasswordResetRequestDto> requestPasswordReset(
+        @Valid @RequestBody ReqPasswordResetRequestDto requestDto) {
+        ownerService.requestPasswordReset(requestDto);
+        return ResponseEntity.ok(new ResPasswordResetRequestDto(
+            "해당 이메일로 가입된 계정이 있다면 비밀번호 재설정 링크가 발송됩니다."
+        ));
+    }
+
+    @Operation(summary = "비밀번호 재설정 확인", description = "토큰을 사용하여 새 비밀번호로 변경합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "비밀번호가 성공적으로 변경되었습니다"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content())
+    })
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<Void> resetPassword(@Valid @RequestBody ReqPasswordResetDto requestDto) {
+        ownerService.resetPassword(requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "내 계정 탈퇴", description = "로그인한 점주가 본인 계정을 탈퇴합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.OWNER)
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteCurrentOwner(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ownerService.deleteCurrentOwner(userDetails);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "점주 탈퇴 (관리자용)", description = "관리자가 특정 점주를 탈퇴 처리합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "탈퇴 처리 완료"),
+        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "점주를 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Secured(UserRoleEnum.Authority.MANAGER)
+    @DeleteMapping("/{ownerUserPublicId}")
+    public ResponseEntity<Void> deleteOwnerByManager(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable UUID ownerUserPublicId) {
+        ownerService.deleteOwnerByManager(userDetails, ownerUserPublicId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ReqChangePasswordDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ReqChangePasswordDto.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.backend.customer.dto;
+package com.sparta.delivery.backend.owner.dto;
 
 import com.sparta.delivery.backend.global.validation.annotation.ValidPassword;
 
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Schema(name = "ReqChangePasswordDto",description = "비밀번호 변경 요청")
+@Schema(name = "ReqChangePasswordDto", description = "비밀번호 변경 요청")
 public class ReqChangePasswordDto {
 
 	@Schema(description = "현재 비밀번호", example = "OldPassword123!")

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ReqCreateOwnerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ReqCreateOwnerDto.java
@@ -1,8 +1,9 @@
 package com.sparta.delivery.backend.owner.dto;
 
-import com.sparta.delivery.backend.global.annotation.validate.ValidPassword;
-import com.sparta.delivery.backend.global.annotation.validate.ValidUsername;
+import com.sparta.delivery.backend.global.validation.annotation.ValidPassword;
+import com.sparta.delivery.backend.global.validation.annotation.ValidUsername;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -11,29 +12,33 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(name = "ReqCreateOwnerDto", description = "점주 회원가입 요청")
 public class ReqCreateOwnerDto {
 
+	@Schema(description = "사용자 아이디", example = "owner1")
 	@ValidUsername
 	private String username;
 
+	@Schema(description = "비밀번호", example = "Password123!")
 	@ValidPassword
 	private String password;
 
+	@Schema(description = "닉네임", example = "홍길동")
 	@NotBlank(message = "닉네임은 필수입니다.")
 	@Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
 	private String nickname;
 
+	@Schema(description = "이메일", example = "owner@example.com")
 	@NotBlank(message = "이메일은 필수입니다.")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	@Size(max = 320, message = "이메일은 최대 320자까지 가능합니다.")
 	private String email;
 
+	@Schema(description = "전화번호", example = "010-1234-5678")
 	@Size(max = 20, message = "전화번호는 최대 20자까지 가능합니다.")
 	private String phoneNumber;
 
-	@Size(min = 12, max = 12, message = "사업자등록번호는 12자여야 합니다.")
-	private String businessNumber;
-
+	@Schema(description = "이메일 인증 토큰", example = "550e8400-e29b-41d4-a716-446655440000")
 	@NotBlank(message = "이메일 인증 토큰은 필수입니다.")
 	private String emailVerificationToken;
 }

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ReqPasswordResetDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ReqPasswordResetDto.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.backend.customer.dto;
+package com.sparta.delivery.backend.owner.dto;
 
 import com.sparta.delivery.backend.global.validation.annotation.ValidPassword;
 
@@ -13,12 +13,12 @@ import lombok.NoArgsConstructor;
 @Schema(name = "ReqPasswordResetDto", description = "비밀번호 재설정")
 public class ReqPasswordResetDto {
 
-	@Schema(description = "이메일", example = "customer@example.com")
+	@Schema(description = "이메일", example = "owner@example.com")
 	@NotBlank(message = "이메일은 필수입니다.")
-	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@Email(message = "유효한 이메일 형식이 아닙니다.")
 	private String email;
 
-	@Schema(description = "재설정 토큰", example = "abc123-def456-ghi789")
+	@Schema(description = "재설정 토큰", example = "550e8400-e29b-41d4-a716-446655440000")
 	@NotBlank(message = "토큰은 필수입니다.")
 	private String token;
 

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ReqPasswordResetRequestDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ReqPasswordResetRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.delivery.backend.owner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "ReqPasswordResetRequestDto", description = "비밀번호 재설정 요청")
+public class ReqPasswordResetRequestDto {
+
+	@Schema(description = "이메일", example = "owner@example.com")
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "유효한 이메일 형식이 아닙니다.")
+	private String email;
+}

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ReqUpdateOwnerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ReqUpdateOwnerDto.java
@@ -1,0 +1,16 @@
+package com.sparta.delivery.backend.owner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "ReqUpdateOwnerDto", description = "점주 정보 수정 요청")
+public class ReqUpdateOwnerDto {
+
+	@Schema(description = "닉네임", example = "홍길동")
+	@Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
+	private String nickname;
+}

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ResGetMyOwnerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ResGetMyOwnerDto.java
@@ -1,0 +1,39 @@
+package com.sparta.delivery.backend.owner.dto;
+
+import java.time.Instant;
+
+import com.sparta.delivery.backend.owner.entity.Owner;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(name = "ResGetMyOwnerDto", description = "점주 마이페이지 조회")
+public class ResGetMyOwnerDto {
+	@Schema(description = "사용자 아이디", example = "owner1")
+	private String username;
+
+	@Schema(description = "닉네임", example = "홍길동")
+	private String nickname;
+
+	@Schema(description = "이메일", example = "owner@example.com")
+	private String email;
+
+	@Schema(description = "전화번호", example = "010-1234-5678")
+	private String phoneNumber;
+
+	@Schema(description = "가입일시", example = "2025-01-15T10:30:00Z")
+	private Instant createdAt;
+
+	public static ResGetMyOwnerDto from(Owner owner) {
+		return ResGetMyOwnerDto.builder()
+			.username(owner.getUser().getUsername())
+			.nickname(owner.getNickname())
+			.email(owner.getEmail())
+			.phoneNumber(owner.getPhoneNumber())
+			.createdAt(owner.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ResGetOwnerDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ResGetOwnerDto.java
@@ -1,0 +1,48 @@
+package com.sparta.delivery.backend.owner.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.sparta.delivery.backend.owner.entity.Owner;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(name = "ResGetOwnerDto", description = "점주 정보 조회 응답 (관리자용)")
+public class ResGetOwnerDto {
+	@Schema(description = "점주 사용자 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+	private UUID ownerUserPublicId;
+
+	@Schema(description = "사용자 아이디", example = "owner1")
+	private String username;
+
+	@Schema(description = "닉네임", example = "홍길동")
+	private String nickname;
+
+	@Schema(description = "이메일", example = "owner@example.com")
+	private String email;
+
+	@Schema(description = "전화번호", example = "010-1234-5678")
+	private String phoneNumber;
+
+	@Schema(description = "가입일시", example = "2025-01-15T10:30:00Z")
+	private Instant createdAt;
+
+	@Schema(description = "수정일시", example = "2025-01-20T14:20:00Z")
+	private Instant updatedAt;
+
+	public static ResGetOwnerDto from(Owner owner) {
+		return ResGetOwnerDto.builder()
+			.ownerUserPublicId(owner.getUser().getPublicId())
+			.username(owner.getUser().getUsername())
+			.nickname(owner.getNickname())
+			.email(owner.getEmail())
+			.phoneNumber(owner.getPhoneNumber())
+			.createdAt(owner.getCreatedAt())
+			.updatedAt(owner.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/sparta/delivery/backend/owner/dto/ResPasswordResetRequestDto.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/dto/ResPasswordResetRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.backend.owner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(name = "ResPasswordResetRequestDto", description = "비밀번호 재설정 요청 응답")
+public class ResPasswordResetRequestDto {
+	
+	@Schema(description = "응답 메시지", example = "해당 이메일로 가입된 계정이 있다면 비밀번호 재설정 링크가 발송됩니다.")
+	private String message;
+}

--- a/src/main/java/com/sparta/delivery/backend/owner/entity/Owner.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/entity/Owner.java
@@ -28,15 +28,23 @@ public class Owner extends BaseEntity {
     @Column(name = "phone_number", length = 20)
     private String phoneNumber;
 
-    @Column(name = "business_number", length = 12)
-    private String businessNumber;
-
     @Builder
-    private Owner(User user, String nickname, String email, String phoneNumber, String businessNumber) {
+    private Owner(User user, String nickname, String email, String phoneNumber) {
         this.user = user;
         this.nickname = nickname;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.businessNumber = businessNumber;
     }
+
+    public void updateNickname(String nickname) {
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname;
+        }
+    }
+
+	public void delete(Long deletedBy) {
+		this.email = this.email + "_deleted_" + getId();
+		this.softDelete(deletedBy);
+		user.softDelete(deletedBy); // 다른 PR(고객 탈퇴 기능)에 포함된 기능 추후 반영
+	}
 }

--- a/src/main/java/com/sparta/delivery/backend/owner/entity/Owner.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/entity/Owner.java
@@ -22,7 +22,7 @@ public class Owner extends BaseEntity {
     @Column(name = "nickname", length = 50, nullable = false)
     private String nickname;
 
-    @Column(name = "email", length = 320, unique = true, nullable = false)
+    @Column(name = "email", length = 512, unique = true, nullable = false)
     private String email;
 
     @Column(name = "phone_number", length = 20)

--- a/src/main/java/com/sparta/delivery/backend/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/repository/OwnerRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sparta.delivery.backend.owner.entity.Owner;
@@ -12,5 +14,24 @@ import com.sparta.delivery.backend.owner.entity.Owner;
 public interface OwnerRepository extends JpaRepository<Owner, UUID> {
 
 	Owner findByUser_PublicId(UUID publicId);
+	
 	Optional<Owner> findByUserId(Long id);
+	
+	@Query("SELECT o FROM Owner o " +
+		"JOIN FETCH o.user " +
+		"WHERE o.user.id = :userId " +
+		"AND o.deletedAt IS NULL")
+	Optional<Owner> findByUserIdAndDeletedAtIsNull(@Param("userId") Long userId);
+	
+	@Query("SELECT o FROM Owner o " +
+		"JOIN FETCH o.user " +
+		"WHERE o.user.publicId = :publicId " +
+		"AND o.deletedAt IS NULL")
+	Optional<Owner> findByUserPublicIdAndDeletedAtIsNull(@Param("publicId") UUID userPublicId);
+	
+	@Query("SELECT o FROM Owner o " +
+		"JOIN FETCH o.user " +
+		"WHERE o.email = :email " +
+		"AND o.deletedAt IS NULL")
+	Optional<Owner> findByEmailAndDeletedAtIsNull(@Param("email") String email);
 }

--- a/src/main/java/com/sparta/delivery/backend/owner/service/OwnerService.java
+++ b/src/main/java/com/sparta/delivery/backend/owner/service/OwnerService.java
@@ -1,34 +1,50 @@
 package com.sparta.delivery.backend.owner.service;
 
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.delivery.backend.global.excpetion.DuplicateUsernameException;
+import com.sparta.delivery.backend.global.infra.email.EmailSender;
+import com.sparta.delivery.backend.global.infra.redis.RedisKeyConstants;
 import com.sparta.delivery.backend.global.verification.EmailVerificationTokenValidator;
+import com.sparta.delivery.backend.owner.dto.ReqChangePasswordDto;
 import com.sparta.delivery.backend.owner.dto.ReqCreateOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ReqPasswordResetDto;
+import com.sparta.delivery.backend.owner.dto.ReqPasswordResetRequestDto;
+import com.sparta.delivery.backend.owner.dto.ReqUpdateOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ResGetMyOwnerDto;
+import com.sparta.delivery.backend.owner.dto.ResGetOwnerDto;
 import com.sparta.delivery.backend.owner.entity.Owner;
 import com.sparta.delivery.backend.owner.repository.OwnerRepository;
+import com.sparta.delivery.backend.security.UserDetailsImpl;
 import com.sparta.delivery.backend.user.entity.User;
 import com.sparta.delivery.backend.user.entity.UserRoleEnum;
 import com.sparta.delivery.backend.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class OwnerService {
 	private final OwnerRepository ownerRepository;
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final EmailVerificationTokenValidator emailVerificationTokenValidator;
+	private final RedisTemplate redisTemplate;
+	private final EmailSender emailSender;
 
-	//TODO: 1. 사업자 등록번호 검증
 	@Transactional
 	public void createOwner(ReqCreateOwnerDto requestDto) {
-		//같은 메일로 다른 사용자 요청 가능하도록 할지 정책 결정필요
-		userRepository.findByUsername(requestDto.getUsername())
+		userRepository.findByUsernameAndDeletedAtIsNull(requestDto.getUsername())
 			.ifPresent(user -> {
 				throw new DuplicateUsernameException("이미 존재하는 사용자명입니다.");
 			});
@@ -44,9 +60,127 @@ public class OwnerService {
 			.nickname(requestDto.getNickname())
 			.phoneNumber(requestDto.getPhoneNumber())
 			.email(requestDto.getEmail())
-			.businessNumber(requestDto.getBusinessNumber())
 			.build();
 
 		ownerRepository.save(owner);
+	}
+
+	public ResGetMyOwnerDto getCurrentOwner(UserDetailsImpl userDetails) {
+		Owner owner = getOwnerByUserId(userDetails);
+		return ResGetMyOwnerDto.from(owner);
+	}
+
+	public ResGetOwnerDto getOwnerByUserPublicId(UUID ownerUserPublicId) {
+		Owner owner = ownerRepository.findByUserPublicIdAndDeletedAtIsNull(ownerUserPublicId)
+			.orElseThrow(() -> new IllegalArgumentException("잘못된 유저 아이디 입니다."));
+		return ResGetOwnerDto.from(owner);
+	}
+
+	@Transactional
+	public void updateCurrentOwner(UserDetailsImpl userDetails, ReqUpdateOwnerDto requestDto) {
+		Owner owner = getOwnerByUserId(userDetails);
+		owner.updateNickname(requestDto.getNickname());
+	}
+
+	@Transactional
+	public void changePassword(UserDetailsImpl userDetails, ReqChangePasswordDto requestDto) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userDetails.getId())
+			.orElseThrow(() -> new IllegalArgumentException("잘못된 유저 아이디 입니다."));
+
+		if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
+			throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+		}
+		if (!requestDto.getNewPassword().equals(requestDto.getNewPasswordConfirm())) {
+			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+		}
+
+		String newEncodedPassword = passwordEncoder.encode(requestDto.getNewPassword());
+		user.changePassword(newEncodedPassword);
+	}
+
+	@Transactional
+	public void requestPasswordReset(ReqPasswordResetRequestDto requestDto) {
+		Optional<Owner> ownerOpt = ownerRepository.findByEmailAndDeletedAtIsNull(requestDto.getEmail());
+
+		if (ownerOpt.isEmpty()) {
+			log.info("비밀번호 재설정 요청 - 존재하지 않는 이메일: {}", requestDto.getEmail());
+			return;
+		}
+
+		Owner owner = ownerOpt.get();
+
+		// 토큰 생성 및 이메일 발송
+		String resetToken = UUID.randomUUID().toString();
+		String key = RedisKeyConstants.PASSWORD_RESET_PREFIX + owner.getEmail();
+		redisTemplate.opsForValue().set(key, resetToken, 30, TimeUnit.MINUTES);
+
+		//TODO: 프론트 존재시 프론트의 링크에 parameter를 포함시켜 해당 링크로 이동하도록 구성
+		String emailBody = String.format("""
+        비밀번호 재설정 요청이 접수되었습니다.
+        
+        아래 정보를 사용하여 비밀번호를 재설정하세요:
+        
+        이메일: %s
+        토큰: %s
+        
+        [Swagger 또는 Postman에서 테스트]
+        POST /v1/owners/password-reset/confirm
+        
+        요청 본문:
+        {
+          "email": "%s",
+          "token": "%s",
+          "newPassword": "새비밀번호",
+          "newPasswordConfirm": "새비밀번호"
+        }
+        
+        이 토큰은 30분간 유효합니다.
+        """,
+			owner.getEmail(),
+			resetToken,
+			owner.getEmail(),
+			resetToken
+		);
+		emailSender.sendMail(owner.getEmail(), "칠면조 배달서비스 비밀번호 재설정 메일입니다.", emailBody);
+	}
+
+	@Transactional
+	public void resetPassword(ReqPasswordResetDto requestDto) {
+		String key = RedisKeyConstants.PASSWORD_RESET_PREFIX + requestDto.getEmail();
+		Object storedToken = redisTemplate.opsForValue().get(key);
+
+		if (storedToken == null || !storedToken.toString().equals(requestDto.getToken())) {
+			throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+		}
+
+		if (!requestDto.getNewPassword().equals(requestDto.getNewPasswordConfirm())) {
+			throw new IllegalArgumentException("새 비밀번호가 일치하지 않습니다.");
+		}
+
+		Owner owner = ownerRepository.findByEmailAndDeletedAtIsNull(requestDto.getEmail())
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		User user = owner.getUser();
+		user.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+
+		redisTemplate.delete(key);
+	}
+
+	@Transactional
+	public void deleteCurrentOwner(UserDetailsImpl userDetails) {
+		Owner owner = getOwnerByUserId(userDetails);
+		owner.delete(userDetails.getId());
+	}
+
+	@Transactional
+	public void deleteOwnerByManager(UserDetailsImpl userDetails, UUID ownerUserPublicId) {
+		Owner owner = ownerRepository.findByUserPublicIdAndDeletedAtIsNull(ownerUserPublicId)
+			.orElseThrow(() -> new IllegalArgumentException("잘못된 유저 아이디 입니다."));
+		owner.delete(userDetails.getId());
+	}
+
+	private Owner getOwnerByUserId(UserDetailsImpl userDetails) {
+		return ownerRepository.findByUserIdAndDeletedAtIsNull(userDetails.getId())
+			.orElseThrow(() -> new IllegalArgumentException("잘못된 유저 아이디 입니다."));
 	}
 }

--- a/src/main/java/com/sparta/delivery/backend/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/delivery/backend/security/UserDetailsServiceImpl.java
@@ -19,7 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		User user = userRepository.findByUsername(username)
+		User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
 			.orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
 		return new UserDetailsImpl(user);

--- a/src/main/java/com/sparta/delivery/backend/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/backend/security/config/WebSecurityConfig.java
@@ -68,6 +68,8 @@ public class WebSecurityConfig {
 					.requestMatchers("/v1/email/send-verification").permitAll()
 					.requestMatchers("/v1/customers/password-reset/request").authenticated()
 					.requestMatchers("/v1/customers/password-reset/confirm").authenticated()
+					.requestMatchers("/v1/owners/password-reset/confirm").authenticated()
+					.requestMatchers("/v1/owners/password-reset/request").authenticated()
 					.requestMatchers("/v1/email/verify").permitAll()
 					//TODO: 추후 개발 완성전 manager등록 API 필터 거치도록 변경
 					.requestMatchers("/v1/managers").permitAll()

--- a/src/main/java/com/sparta/delivery/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/user/repository/UserRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByUsername(String username);
+	Optional<User> findByUsernameAndDeletedAtIsNull(String username);
+
+	Optional<User> findByIdAndDeletedAtIsNull(Long id);
 }


### PR DESCRIPTION
## 📌 개요
- 점주 관련 기능 구현

## 🔨 변경 사항
- 점주 이메일 컬럼 제약조건 변경 및 사업자 번호 컬럼 제거
- 점주 관련 API 전체 swagger 적용
- 점주 내정보 조회 API
- 점주 정보 조회 관리자용 API
- 점주 내정보 수정 API
- 로그인한 상태의 비밀번호 변경 API
- 비로그인 비밀번호 재설정 요청/확인 API
- 점주 내계정 탈퇴 API
- 점주 탈퇴 관리자용 API

## ✅ 테스트
- [ ] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- 고객 탈퇴에 User 변경사항이 포함되어 있어, Test코드는 이후 작성하도록 하겠습니다!