### PR TITLE
fix(ai): AI 프롬프트 목록 조회 시 swagger에서 pagination 없이도 요청할 수 있도록 수정

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
@@ -2,8 +2,11 @@ package com.sparta.delivery.backend.ai.controller;
 
 import static com.sparta.delivery.backend.ai.internal.AiSwaggerMessage.*;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,7 +22,6 @@ import com.sparta.delivery.backend.ai.dto.ResReadAiPromptDto;
 import com.sparta.delivery.backend.ai.service.AiPromptService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -73,11 +75,11 @@ public class AiPromptController {
 				@ExampleObject(name = "권한 부족", value = AI_FORBIDDEN),
 			}))
 	})
+	@PageableAsQueryParam
 	@GetMapping
 	@PreAuthorize("isAuthenticated() && hasRole('MANAGER')")
 	public ResponseEntity<Page<ResReadAiPromptDto>> getAllAiPrompt(
-		@Parameter(example = "{\"page\":0,\"size\":10,\"sort\":\"id,desc\"}") Pageable pageable
-	) {
+		@ParameterObject @PageableDefault Pageable pageable) {
 		Page<ResReadAiPromptDto> responseDtoList = aiPromptService.getAllAiPrompts(pageable);
 
 		return ResponseEntity.ok(responseDtoList);


### PR DESCRIPTION
## 📌 개요
- AI 프롬프트 목록 조회 시 swagger에서 pagination 없이도 요청할 수 있도록 수정

## 🔨 변경 사항
- AI 프롬프트 목록 조회 시 swagger에서 pagination 없이도 요청할 수 있도록 수정

## ✅ 테스트
- [ ] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [ ] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?