### PR TITLE
feat(address): 주소 생성 시 길이 제한 제약조건 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
+++ b/src/main/java/com/sparta/delivery/backend/address/dto/ReqRegisterAddressDto.java
@@ -2,6 +2,7 @@ package com.sparta.delivery.backend.address.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,11 +10,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ReqRegisterAddressDto {
 
-	@Schema(description = "법정동 코드", example = "103", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "법정동 코드", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "법정동 코드는 필수 입력 값입니다.")
 	private String regionCode;
 
-	@Schema(description = "주소", example = "서울특별시 마포구 망원1동 마포나루길 4", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "주소", example = "서울특별시 마포구 망원1동 마포나루길 4", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 255)
 	@NotBlank(message = "주소는 필수 입력 값입니다.")
+	@Size(min = 10, max = 255, message = "주소는 최소 10자, 최대 255자까지 가능합니다.")
 	private String address;
 }


### PR DESCRIPTION
## 📌 개요
- 주소 길이 제약조건

## 🔨 변경 사항
- 주소 생성 시 최소 10자, 최대 255자 제약조건 추가

## ✅ 테스트
- [x] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?