### PR TITLE
feat/fix-storeMenu,order

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
@@ -3,6 +3,12 @@ package com.sparta.delivery.backend.order.controller;
 import com.sparta.delivery.backend.order.dto.*;
 import com.sparta.delivery.backend.order.service.OrderService;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,12 +29,23 @@ public class OrderController {
 
 	// Customer 가 주문 하기 전 Cart 의 정보들을 확인하는 화면
 	@GetMapping("/checkout")
+	@Operation(summary = "주문 결제 전 화면 조회", description = "Customer가 주문 생성 전에 장바구니 정보, 배송지, 금액을 확인합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "주문 정보 조회 성공", content = @Content(schema = @Schema(implementation = ResCheckOutOrderDto.class))),
+		@ApiResponse(responseCode = "400", description = "장바구니가 비어있거나 주소 정보 없음")
+	})
 	public ResCheckOutOrderDto getCheckoutOrder(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return orderService.getCheckoutOrder(userDetails.getUser());
 	}
 
 	// Customer 가 주문 생성 ( Cart 에서 정보들을 가져와서 주문 처리만 하는 Flow )
 	@PostMapping
+	@Operation(summary = "주문 생성", description = "Customer가 장바구니에 담긴 정보를 기반으로 주문을 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "주문 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "주소 정보나 장바구니 정보 없음"),
+		@ApiResponse(responseCode = "403", description = "본인 장바구니가 아님")
+	})
 	public ResponseEntity<UUID> createOrder(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestBody ReqCreateOrderDto reqCreateOrderDto
@@ -39,6 +56,11 @@ public class OrderController {
 
 	// Customer / Owner 가 자신의 주문 내역 전체 조회
 	@GetMapping("/me")
+	@Operation(summary = "주문 내역 전체 조회", description = "주문 내역을 페이징 형태로 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "주문 내역 조회 성공", content = @Content(schema = @Schema(implementation = ResGetListOrderDto.class))),
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 정보")
+	})
 	public ResponseEntity<Page<ResGetListOrderDto>> getOrdersByUserId(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestParam("page") int page,
@@ -57,6 +79,11 @@ public class OrderController {
 
 	// 주문 상세 정보 조회
 	@GetMapping("/{orderId}")
+	@Operation(summary = "주문 내역 상세 조회", description = "자신의 주문 내역을 페이징 형태로 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "주문 내역 조회 성공", content = @Content(schema = @Schema(implementation = ResGetListOrderDto.class))),
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 정보")
+	})
 	public ResponseEntity<ResGetOrderDto> getOrderById(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID orderId
@@ -67,6 +94,12 @@ public class OrderController {
 
 	// Owner 가 주문 수락 or 주문 취소 -> 취소 사유 전달
 	@PatchMapping("/{orderId}/status")
+	@Operation(summary = "주문 상태 변경", description = "Owner가 주문을 수락하거나 취소합니다. Customer는 주문 생성 5분 이내 && Owner가 주문 상태를 변경하기 전에만 취소할 수 있습니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "주문 상태 변경 성공"),
+		@ApiResponse(responseCode = "400", description = "주문이 존재하지 않음 또는 잘못된 상태 변경 요청"),
+		@ApiResponse(responseCode = "403", description = "Owner 또는 고객 권한 없음")
+	})
 	public ResponseEntity<Void> updateOrderStatusDto(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID orderId,
@@ -78,6 +111,12 @@ public class OrderController {
 
 	// Customer 가 주문 내역 삭제
 	@DeleteMapping("/{orderId}")
+	@Operation(summary = "주문 내역 삭제", description = "Customer가 자신의 주문 내역을 삭제합니다. 진행 중인 주문은 삭제할 수 없습니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "204", description = "주문 삭제 성공"),
+		@ApiResponse(responseCode = "400", description = "주문이 존재하지 않거나 진행 중인 주문"),
+		@ApiResponse(responseCode = "403", description = "본인 주문이 아님")
+	})
 	public ResponseEntity<Void> deleteOrder(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID orderId

--- a/src/main/java/com/sparta/delivery/backend/order/dto/ResCheckOutOrderDto.java
+++ b/src/main/java/com/sparta/delivery/backend/order/dto/ResCheckOutOrderDto.java
@@ -28,7 +28,7 @@ public class ResCheckOutOrderDto {
 	@Schema(description = "상세 주소", example = "백양로 65")
 	private String addressDetail;
 
-	@Schema(description = "고객 연락처", example = "01012345678")
+	@Schema(description = "고객 연락처", example = "010-1234-5678")
 	private String phoneNumber;
 
 	@Schema(description = "메뉴 합계", example = "13000")

--- a/src/main/java/com/sparta/delivery/backend/order/dto/ResCheckOutOrderDto.java
+++ b/src/main/java/com/sparta/delivery/backend/order/dto/ResCheckOutOrderDto.java
@@ -28,7 +28,7 @@ public class ResCheckOutOrderDto {
 	@Schema(description = "상세 주소", example = "백양로 65")
 	private String addressDetail;
 
-	@Schema(description = "고객 연락처", example = "010-1234-5678")
+	@Schema(description = "고객 연락처", example = "01012345678")
 	private String phoneNumber;
 
 	@Schema(description = "메뉴 합계", example = "13000")

--- a/src/main/java/com/sparta/delivery/backend/order/dto/ResGetOrderDto.java
+++ b/src/main/java/com/sparta/delivery/backend/order/dto/ResGetOrderDto.java
@@ -43,7 +43,7 @@ public class ResGetOrderDto {
 	@Schema(description = "상세 주소", example = "백양로 65")
 	private String addressDetail;
 
-	@Schema(description = "고객 연락처", example = "010-1234-5678")
+	@Schema(description = "고객 연락처", example = "01012345678")
 	private String phoneNumber;
 
 	@Schema(description = "주문 생성일", example = "2025-10-13T06:43:02.892Z")

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -1,5 +1,7 @@
 package com.sparta.delivery.backend.order.service;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -158,6 +160,24 @@ public class OrderService {
 	public void updateOrderStatus(User user, UUID orderId, ReqUpdateOrderStatusDto reqUpdateOrderStatusDto) {
 		// 단건 주문 조회
 		Order order = findOrderOrThrow(orderId);
+
+		// 고객 취소 허용: 주문 생성 후 5분 이내 && 요청 상태가 주문 중(취소 가능)
+		boolean isCustomer = user.getRole() == UserRoleEnum.CUSTOMER;
+		boolean isCancelRequest = reqUpdateOrderStatusDto.getOrderStatus() == OrderStatus.CANCELLED;
+
+		if (isCustomer && isCancelRequest) {
+			if (order.getOrderStatus() != OrderStatus.ORDERED) {
+				throw new IllegalStateException("주문중 상태에만 주문을 취소할 수 있습니다.");
+			}
+			long minutesSinceOrder = ChronoUnit.MINUTES.between(order.getCreatedAt(), Instant.now());
+			if (minutesSinceOrder <= 5) {
+				order.updateOrderStatus(user, reqUpdateOrderStatusDto);
+				orderRepository.save(order);
+				return;
+			} else {
+				throw new IllegalStateException("주문 5분 이내에만 주문을 취소할 수 있습니다.");
+			}
+		}
 
 		// 권한 확인: 이 주문의 가게 주인인지 확인
 		if (!order.getStore().getOwner().getUser().getId().equals(user.getId())) {

--- a/src/main/java/com/sparta/delivery/backend/store/menu/controller/StoreMenuController.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/controller/StoreMenuController.java
@@ -49,11 +49,12 @@ public class StoreMenuController {
 			@ApiResponse(responseCode = "400", description = "가게 없음")
 	})
 	public ResponseEntity<Page<ResGetListStoreMenuDto>> getAllStoreMenusByStoreId(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID storeId,
 		@RequestParam("page") int page,
 		@RequestParam("size") int size
 	) {
-		Page<ResGetListStoreMenuDto> menus = storeMenuService.getStoreMenusByStoreId(storeId, page - 1, size);
+		Page<ResGetListStoreMenuDto> menus = storeMenuService.getStoreMenusByStoreId(userDetails.getUser(), storeId, page - 1, size);
 		return ResponseEntity.ok(menus);
 	}
 

--- a/src/main/java/com/sparta/delivery/backend/store/menu/repository/StoreMenuRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/repository/StoreMenuRepository.java
@@ -25,5 +25,7 @@ public interface StoreMenuRepository extends JpaRepository<StoreMenu, UUID>, Sto
 	// Owner: 삭제한 StoreMenu 들은 조회할 필요 없음
 	Page<StoreMenu> findAllByStoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
 
+	Page<StoreMenu> findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(UUID storeId, Pageable pageable);
+
 	Optional<StoreMenu> findByStoreIdAndName(UUID storeId, String name);
 }

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -86,15 +86,21 @@ public class StoreMenuService {
 		int page,
 		int size
 	) {
-		storeRepository.findById(storeId)
+		Store store = storeRepository.findById(storeId)
 			.orElseThrow(() -> new IllegalArgumentException("Store not found"));
 
 		Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
 
 		Page<StoreMenu> storeMenuList;
 
-		// 기본값은 삭제되지 않은 값들만 조회
-		storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+		// Customer || Owner 이지만 본인의 가게가 아닌 경우
+		if (user.getRole() == UserRoleEnum.CUSTOMER || !store.getOwner().getUser().getPublicId().equals(user.getPublicId())) {
+			// 숨김되지 않은 메뉴만 조회
+			storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(storeId, pageable);
+		} else {
+			// 가게의 Owner, Manager, Master는 숨김된 메뉴 포함 조회
+			storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+		}
 
 		/* 현재는 Manager, Master 도 삭제된 값들을 보지 못하도록 설계하기로 결정
 		// UserRole이 Manager, Master이면 softDelete 된 목록들도 조회할 수 있게 처리

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -93,12 +93,18 @@ public class StoreMenuService {
 
 		Page<StoreMenu> storeMenuList;
 
-		// UserRole이 Manager || Master이면 softDelete 된 목록들도 조회할 수 있게 처리
-		if (user.getRole() == UserRoleEnum.MANAGER || user.getRole() == UserRoleEnum.MASTER) {
+		// 기본값은 삭제되지 않은 값들만 조회
+		storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+
+		/* 현재는 Manager, Master 도 삭제된 값들을 보지 못하도록 설계하기로 결정
+		// UserRole이 Manager, Master이면 softDelete 된 목록들도 조회할 수 있게 처리
+
+		if (user.getRole() == UserRoleEnum.MANAGER) {
 			storeMenuList = storeMenuRepository.findAllByStoreId(storeId, pageable);
-		} else {
-			storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+		} else if (user.getRole() == UserRoleEnum.MASTER) {
+			storeMenuList = storeMenuRepository.findAllByStoreId(storeId, pageable);
 		}
+		*/
 
 		// 메뉴가 하나도 없어도 빈 페이지는 반환
 		if (storeMenuList == null || storeMenuList.isEmpty()) {

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -42,8 +42,6 @@ public class StoreMenuService {
 		UUID storeId,
 		ReqCreateStoreMenuDto reqCreateStoreMenuDto
 	) {
-
-
 		Store store = validatePermission(user, storeId);
 		validateDuplicateMenuName(storeId, reqCreateStoreMenuDto.getName());
 

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -81,6 +81,7 @@ public class StoreMenuService {
 	// 전체 메뉴 조회 (페이징)
 	@Transactional(readOnly = true)
 	public Page<ResGetListStoreMenuDto> getStoreMenusByStoreId(
+		User user,
 		UUID storeId,
 		int page,
 		int size
@@ -90,8 +91,14 @@ public class StoreMenuService {
 
 		Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
 
-		Page<StoreMenu> storeMenuList =
-			storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+		Page<StoreMenu> storeMenuList;
+
+		// UserRole이 Manager || Master이면 softDelete 된 목록들도 조회할 수 있게 처리
+		if (user.getRole() == UserRoleEnum.MANAGER || user.getRole() == UserRoleEnum.MASTER) {
+			storeMenuList = storeMenuRepository.findAllByStoreId(storeId, pageable);
+		} else {
+			storeMenuList = storeMenuRepository.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
+		}
 
 		// 메뉴가 하나도 없어도 빈 페이지는 반환
 		if (storeMenuList == null || storeMenuList.isEmpty()) {

--- a/src/test/java/com/sparta/delivery/backend/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/sparta/delivery/backend/order/repository/OrderRepositoryTest.java
@@ -79,7 +79,7 @@ class OrderRepositoryTest {
 			.user(ownerUser)
 			.nickname("테스트점주")
 			.email("owner@test.com")
-			.phoneNumber("010-0000-0000")
+			.phoneNumber("01000000000")
 			.build();
 		em.persist(owner);
 
@@ -87,7 +87,7 @@ class OrderRepositoryTest {
 			.user(customerUser)
 			.nickname("테스트고객")
 			.email("hong@test.com")
-			.phoneNumber("010-1234-5678")
+			.phoneNumber("01012345678")
 			.build();
 		em.persist(customer);
 
@@ -122,13 +122,13 @@ class OrderRepositoryTest {
 		store = Store.builder()
 			.owner(owner)
 			.name("테스트가게")
-			.addressDetails("서울시 강남구")
+			.addressDetails("서울시 강남구 어디인가입니다")
 			.reviewRate(4.5)
 			.minOrderPrice(10000)
 			.deliveryFee(2000)
 			.regionDong(dong)
 			.status(StoreStatusEnum.OPEN)
-			.phoneNumber("02-1111-2222")
+			.phoneNumber("03111112222")
 			.build();
 		em.persist(store);
 
@@ -147,7 +147,7 @@ class OrderRepositoryTest {
 			.dongEntity(dong)
 			.gu("강남구")
 			.dong("삼성동")
-			.addressDetails("삼성로 100")
+			.addressDetails("삼성로 100의 주변에 있어요")
 			.orderStatus(OrderStatus.ORDERED)
 			.payMethod(PayMethod.CARD)
 			.build();

--- a/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
@@ -3,6 +3,8 @@ package com.sparta.delivery.backend.order.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -160,6 +162,7 @@ class OrderServiceTest {
 		ReflectionTestUtils.setField(order, "gu", "강남구");
 		ReflectionTestUtils.setField(order, "dong", "삼성동");
 		ReflectionTestUtils.setField(order, "addressDetails", "테스트주소 123입니다아아");
+		ReflectionTestUtils.setField(order, "createdAt", Instant.now());
 
 		// 테스트 이미지
 		image = Image.builder()
@@ -350,13 +353,90 @@ class OrderServiceTest {
 		}
 
 		@Test
-		@DisplayName("실패 - Customer가 상태 변경 시도")
+		@DisplayName("성공 - Customer가 주문 생성 5분 이내에 취소")
+		void cancelByCustomer_within5Minutes_success() {
+			/* given */
+			when(orderRepository.findById(any())).thenReturn(Optional.of(order));
+			when(orderRepository.save(any())).thenReturn(order);
+
+			// 현재 주문 중 상태이고
+			ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.ORDERED);
+
+			// 만약 주문 후 4분이 지났다면
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now().minus(4, ChronoUnit.MINUTES));
+
+			// 취소 요청 가능
+			ReqUpdateOrderStatusDto req = new ReqUpdateOrderStatusDto();
+			req.setOrderStatus(OrderStatus.CANCELLED);
+
+			/* when */
+			orderService.updateOrderStatus(customerUser, order.getId(), req);
+
+			/* then */
+			verify(orderRepository).save(order);
+			assertEquals(OrderStatus.CANCELLED, order.getOrderStatus());
+		}
+
+		@Test
+		@DisplayName("실패 - Customer가 주문 생성 5분 초과 후 취소 시도")
+		void cancelByCustomer_after5Minutes_fail() {
+			/* given */
+			when(orderRepository.findById(any())).thenReturn(Optional.of(order));
+
+			// 현재 주문 중 상태이지만
+			ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.ORDERED);
+
+			// 만약 주문 후 5분이 넘었다면 (10분)
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now().minus(10, ChronoUnit.MINUTES));
+
+			// 취소를 보내도 불가능
+			ReqUpdateOrderStatusDto req = new ReqUpdateOrderStatusDto();
+			req.setOrderStatus(OrderStatus.CANCELLED);
+
+			/* when & then */
+			IllegalStateException ex = assertThrows(
+				IllegalStateException.class,
+				() -> orderService.updateOrderStatus(customerUser, order.getId(), req)
+			);
+
+			assertEquals("주문 5분 이내에만 주문을 취소할 수 있습니다.", ex.getMessage());
+			verify(orderRepository, never()).save(any());
+		}
+
+		@Test
+		@DisplayName("실패 - Customer가 주문 중 상태가 아닌 경우에 취소 시도")
+		void cancelByCustomer_notOrdered_fail() {
+			/* given */
+			when(orderRepository.findById(any())).thenReturn(Optional.of(order));
+
+			// 현재 주문 중 상태가 아니라면
+			ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.ACCEPTED);
+
+			// 만약 주문 후 5분이 안지났더라도
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now().minus(2, ChronoUnit.MINUTES));
+
+			// 취소 불가능
+			ReqUpdateOrderStatusDto req = new ReqUpdateOrderStatusDto();
+			req.setOrderStatus(OrderStatus.CANCELLED);
+
+			/* when & then */
+			IllegalStateException ex = assertThrows(
+				IllegalStateException.class,
+				() -> orderService.updateOrderStatus(customerUser, order.getId(), req)
+			);
+
+			assertEquals("주문중 상태에만 주문을 취소할 수 있습니다.", ex.getMessage());
+			verify(orderRepository, never()).save(any());
+		}
+
+		@Test
+		@DisplayName("실패 - Customer가 주문 수락 시도")
 		void updateStatus_noPermission() {
 			/* given */
 			when(orderRepository.findById(any())).thenReturn(Optional.of(order));
 
 			ReqUpdateOrderStatusDto req = new ReqUpdateOrderStatusDto();
-			req.setOrderStatus(OrderStatus.CANCELLED);
+			req.setOrderStatus(OrderStatus.ACCEPTED);
 
 			/* when & then */
 			assertThrows(IllegalStateException.class,

--- a/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
@@ -159,7 +159,7 @@ class OrderServiceTest {
 		ReflectionTestUtils.setField(order, "dongEntity", dong);
 		ReflectionTestUtils.setField(order, "gu", "강남구");
 		ReflectionTestUtils.setField(order, "dong", "삼성동");
-		ReflectionTestUtils.setField(order, "addressDetails", "테스트주소 123");
+		ReflectionTestUtils.setField(order, "addressDetails", "테스트주소 123입니다아아");
 
 		// 테스트 이미지
 		image = Image.builder()

--- a/src/test/java/com/sparta/delivery/backend/store/menu/repository/StoreMenuRepositoryTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/repository/StoreMenuRepositoryTest.java
@@ -52,20 +52,20 @@ class StoreMenuRepositoryTest {
 			.user(user)
 			.nickname("테스트 사장님")
 			.email("owner@test.com")
-			.phoneNumber("010-1234-5678")
+			.phoneNumber("01012345678")
 			.build();
 		em.persist(owner);
 
 		store = Store.builder()
 			.owner(owner)
 			.name("테스트 가게")
-			.addressDetails("서울시 마포구")
+			.addressDetails("서울시 마포구의 문앞에 있어요")
 			.reviewRate(4.5)
 			.minOrderPrice(10000)
 			.deliveryFee(2000)
 			.regionDong(null)
 			.status(StoreStatusEnum.OPEN)
-			.phoneNumber("02-1234-5678")
+			.phoneNumber("0212345678")
 			.build();
 		em.persist(store);
 
@@ -180,13 +180,13 @@ class StoreMenuRepositoryTest {
 			Store emptyStore = Store.builder()
 				.owner(owner)
 				.name("빈가게")
-				.addressDetails("서울시 중구")
+				.addressDetails("서울시 중구 쯔음에 있어요")
 				.reviewRate(0)
 				.minOrderPrice(0)
 				.deliveryFee(0)
 				.regionDong(null)
 				.status(StoreStatusEnum.OPEN)
-				.phoneNumber("000-0000")
+				.phoneNumber("01012345678")
 				.build();
 			em.persist(emptyStore);
 

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -80,7 +80,7 @@ class StoreMenuServiceTest {
 		owner = Owner.builder()
 			.nickname("Owner1234")
 			.email("testOwner1@naver.com")
-			.phoneNumber("010-2222-3333")
+			.phoneNumber("01022223333")
 			.user(user)
 			.build();
 		ReflectionTestUtils.setField(owner, "id", UUID.randomUUID());
@@ -95,7 +95,7 @@ class StoreMenuServiceTest {
 			.deliveryFee(1500)
 			.regionDong(null) // 추후 필요하면 더미 Dong 생성
 			.status(StoreStatusEnum.OPEN)
-			.phoneNumber("010-1234-5678")
+			.phoneNumber("01012345678")
 			.build();
 		ReflectionTestUtils.setField(store, "id", UUID.randomUUID());
 

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -389,32 +389,118 @@ class StoreMenuServiceTest {
 	class GetListStoreMenuTest {
 
 		@Test
-		@DisplayName("성공")
-		// 추후에 바뀔 가능성 있음
-		// @DisplayName("성공 - Owner는 softDelete 되지 않은 메뉴들만 조회")
-		void getList_success() {
+		@DisplayName("성공 - Customer는 숨김된 메뉴를 조회하지 않음")
+		void getList_customer_excludesHiddenMenus() {
 			/* given */
 			UUID storeId = store.getId();
 			int page = 0;
 			int size = 10;
 			Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
 
-			reqCreateStoreMenuDto = new ReqCreateStoreMenuDto();
-			reqCreateStoreMenuDto.setName("새우버거");
-			reqCreateStoreMenuDto.setImageUrl(image.getImageUrl());
-			reqCreateStoreMenuDto.setPrice(3000);
-			reqCreateStoreMenuDto.setDescription("새우, 마요네즈가 들어있습니다.");
-			reqCreateStoreMenuDto.setPrepTime("10분");
-			reqCreateStoreMenuDto.setStockStatus(StockStatus.LOW_STOCK);
-			reqCreateStoreMenuDto.setIsHidden(false);
+			User customerUser = User.builder()
+				.username("customerUser")
+				.password("pass")
+				.role(UserRoleEnum.CUSTOMER)
+				.build();
+			ReflectionTestUtils.setField(customerUser, "publicId", UUID.randomUUID());
 
-			// 테스트 가게 메뉴
+			// 메뉴 2만 숨김 처리
+			menu1.setHiddenAt(null);
 			menu2 = StoreMenu.builder()
 				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
 				.store(store)
 				.image(image)
 				.build();
-			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID()); // Test UUID 주입
+			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
+			menu2.setHiddenAt(true);
+
+			List<StoreMenu> menuList = List.of(menu1);
+			Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(menuList, pageable,
+				menuList.size());
+
+			when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+			when(storeMenuRepository.findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(storeId, pageable))
+				.thenReturn(pageResult);
+
+			/* when */
+			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(customerUser, storeId, 0,
+				10);
+
+			/* then */
+			assertNotNull(resGetListStoreMenuDto);
+			assertEquals(1, resGetListStoreMenuDto.getContent().size());
+			assertEquals(menu1.getName(), resGetListStoreMenuDto.getContent().get(0).getName());
+			verify(storeMenuRepository, times(1))
+				.findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(storeId, pageable);
+		}
+
+		@Test
+		@DisplayName("성공 - 다른 가게의 Owner는 숨김된 메뉴를 조회하지 않음")
+		void getList_differentOwner_cannotAccessOtherStore() {
+			/* given */
+			UUID storeId = store.getId();
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
+
+			// 새로운 다른 Owner 유저 생성
+			User differentOwner = User.builder()
+				.username("otherOwner")
+				.password("testPass")
+				.role(UserRoleEnum.OWNER)
+				.build();
+			ReflectionTestUtils.setField(differentOwner, "publicId", UUID.randomUUID());
+
+			when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+
+			// 메뉴 2만 숨김 처리
+			menu1.setHiddenAt(null);
+			menu2 = StoreMenu.builder()
+				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
+				.store(store)
+				.image(image)
+				.build();
+			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
+			menu2.setHiddenAt(true);
+
+			List<StoreMenu> menuList = List.of(menu1);
+			Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(menuList, pageable,
+				menuList.size());
+
+			when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+			when(storeMenuRepository.findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(storeId, pageable))
+				.thenReturn(pageResult);
+
+			/* when */
+			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(differentOwner, storeId, 0,
+				10);
+
+			/* then */
+			assertNotNull(resGetListStoreMenuDto);
+			assertEquals(1, resGetListStoreMenuDto.getContent().size());
+			assertEquals(menu1.getName(), resGetListStoreMenuDto.getContent().get(0).getName());
+			verify(storeMenuRepository, times(1))
+				.findAllByStoreIdAndDeletedAtIsNullAndHiddenAtIsNull(storeId, pageable);
+		}
+
+		@Test
+		@DisplayName("성공 - 가게의 Owner 본인은 숨긴 메뉴도 조회 가능")
+		void getList_owner_includesHiddenMenus() {
+			/* given */
+			UUID storeId = store.getId();
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
+
+			// 메뉴 2만 숨김 처리
+			menu1.setHiddenAt(null);
+			menu2 = StoreMenu.builder()
+				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
+				.store(store)
+				.image(image)
+				.build();
+			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
+			menu2.setHiddenAt(true);
 
 			List<StoreMenu> menuList = List.of(menu1, menu2);
 			Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(menuList, pageable,

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -389,7 +389,9 @@ class StoreMenuServiceTest {
 	class GetListStoreMenuTest {
 
 		@Test
-		@DisplayName("성공 - Owner는 softDelete 되지 않은 메뉴들만 조회")
+		@DisplayName("성공")
+		// 추후에 바뀔 가능성 있음
+		// @DisplayName("성공 - Owner는 softDelete 되지 않은 메뉴들만 조회")
 		void getList_success() {
 			/* given */
 			UUID storeId = store.getId();
@@ -434,48 +436,49 @@ class StoreMenuServiceTest {
 				.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);
 		}
 
-		@Test
-		@DisplayName("성공 - MANAGER는 softDelete된 메뉴도 조회 가능")
-		void getList_success_managerCanSeeDeleted() {
-			/* given */
-			UUID storeId = store.getId();
-			int page = 0;
-			int size = 10;
-			Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
-
-			// MANAGER 권한 부여
-			user = User.builder()
-				.username("managerUser")
-				.password("pass")
-				.role(UserRoleEnum.MANAGER)
-				.build();
-			ReflectionTestUtils.setField(user, "publicId", UUID.randomUUID());
-
-			// softDelete된 메뉴 포함
-			menu1.softDelete(user.getPublicId(), -1);
-			menu2 = StoreMenu.builder()
-				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
-				.store(store)
-				.image(image)
-				.build();
-			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
-
-			List<StoreMenu> allMenus = List.of(menu1, menu2);
-			Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(allMenus, pageable, allMenus.size());
-
-			when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
-			when(storeMenuRepository.findAllByStoreId(storeId, pageable))
-				.thenReturn(pageResult);
-
-			/* when */
-			Page<ResGetListStoreMenuDto> result = storeMenuService.getStoreMenusByStoreId(user, storeId, page, size);
-
-			/* then */
-			assertNotNull(result);
-			assertEquals(2, result.getContent().size());
-			verify(storeMenuRepository, times(1))
-				.findAllByStoreId(storeId, pageable);
-		}
+		// 현재 Manager, Master 도 삭제된 메뉴는 안보이도록 설계하기로 결정
+		// @Test
+		// @DisplayName("성공 - Manager, Master는 softDelete된 메뉴도 조회 가능")
+		// void getList_success_managerAndMasterCanSeeDeleted() {
+		// 	/* given */
+		// 	UUID storeId = store.getId();
+		// 	int page = 0;
+		// 	int size = 10;
+		// 	Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
+		//
+		// 	// MANAGER 권한 부여
+		// 	user = User.builder()
+		// 		.username("managerUser")
+		// 		.password("pass")
+		// 		.role(UserRoleEnum.MANAGER)
+		// 		.build();
+		// 	ReflectionTestUtils.setField(user, "publicId", UUID.randomUUID());
+		//
+		// 	// softDelete된 메뉴 포함
+		// 	menu1.softDelete(user.getPublicId(), -1);
+		// 	menu2 = StoreMenu.builder()
+		// 		.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
+		// 		.store(store)
+		// 		.image(image)
+		// 		.build();
+		// 	ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
+		//
+		// 	List<StoreMenu> allMenus = List.of(menu1, menu2);
+		// 	Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(allMenus, pageable, allMenus.size());
+		//
+		// 	when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+		// 	when(storeMenuRepository.findAllByStoreId(storeId, pageable))
+		// 		.thenReturn(pageResult);
+		//
+		// 	/* when */
+		// 	Page<ResGetListStoreMenuDto> result = storeMenuService.getStoreMenusByStoreId(user, storeId, page, size);
+		//
+		// 	/* then */
+		// 	assertNotNull(result);
+		// 	assertEquals(2, result.getContent().size());
+		// 	verify(storeMenuRepository, times(1))
+		// 		.findAllByStoreId(storeId, pageable);
+		// }
 
 		@Test
 		@DisplayName("성공 - Image 미설정 시 기본 Image")

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -389,7 +389,7 @@ class StoreMenuServiceTest {
 	class GetListStoreMenuTest {
 
 		@Test
-		@DisplayName("성공")
+		@DisplayName("성공 - Owner는 softDelete 되지 않은 메뉴들만 조회")
 		void getList_success() {
 			/* given */
 			UUID storeId = store.getId();
@@ -423,7 +423,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(storeId, 0,
+			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
 				10);
 
 			/* then */
@@ -435,7 +435,50 @@ class StoreMenuServiceTest {
 		}
 
 		@Test
-		@DisplayName("성공 - imageUrl이")
+		@DisplayName("성공 - MANAGER는 softDelete된 메뉴도 조회 가능")
+		void getList_success_managerCanSeeDeleted() {
+			/* given */
+			UUID storeId = store.getId();
+			int page = 0;
+			int size = 10;
+			Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
+
+			// MANAGER 권한 부여
+			user = User.builder()
+				.username("managerUser")
+				.password("pass")
+				.role(UserRoleEnum.MANAGER)
+				.build();
+			ReflectionTestUtils.setField(user, "publicId", UUID.randomUUID());
+
+			// softDelete된 메뉴 포함
+			menu1.softDelete(user.getPublicId(), -1);
+			menu2 = StoreMenu.builder()
+				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
+				.store(store)
+				.image(image)
+				.build();
+			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID());
+
+			List<StoreMenu> allMenus = List.of(menu1, menu2);
+			Page<StoreMenu> pageResult = new org.springframework.data.domain.PageImpl<>(allMenus, pageable, allMenus.size());
+
+			when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+			when(storeMenuRepository.findAllByStoreId(storeId, pageable))
+				.thenReturn(pageResult);
+
+			/* when */
+			Page<ResGetListStoreMenuDto> result = storeMenuService.getStoreMenusByStoreId(user, storeId, page, size);
+
+			/* then */
+			assertNotNull(result);
+			assertEquals(2, result.getContent().size());
+			verify(storeMenuRepository, times(1))
+				.findAllByStoreId(storeId, pageable);
+		}
+
+		@Test
+		@DisplayName("성공 - Image 미설정 시 기본 Image")
 		void getList_success_whenImageUrlIsNull() {
 			/* given */
 			UUID storeId = store.getId();
@@ -456,7 +499,7 @@ class StoreMenuServiceTest {
 			menu2 = StoreMenu.builder()
 				.reqCreateStoreMenuDto(reqCreateStoreMenuDto)
 				.store(store)
-				.image(image)
+				.image(null)
 				.build();
 			ReflectionTestUtils.setField(menu2, "id", UUID.randomUUID()); // Test UUID 주입
 
@@ -469,7 +512,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(storeId, 0,
+			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
 				10);
 
 			/* then */
@@ -496,7 +539,7 @@ class StoreMenuServiceTest {
 
 			/* when */
 			Page<ResGetListStoreMenuDto> result =
-				storeMenuService.getStoreMenusByStoreId(storeId, page, size);
+				storeMenuService.getStoreMenusByStoreId(user, storeId, page, size);
 
 			/* then */
 			assertNotNull(result);


### PR DESCRIPTION
## 📌 개요
- 전체적으로 추가 및 수정

## 🔨 변경 사항
- UserRole이 Manager, Master인 경우 softDelete 처리 된 메뉴들도 조회할 수 있게 로직 추가, 기존처럼 Owner는 본인의 StoreMenu는 softDelete 되지 않은 메뉴들만 조회할 수 있다.
- phoneNumber의 데이터 정책에 따른 수정
- address의 최소 10자 ~ 최대 255자 제약 조건에 따른 Test 수정
- StoreMenu: 목록 조회 시 Manager, Master 모두 삭제된 메뉴들 안 보이도록 변경
- Order: 고객이 주문 생성 후 5분 이내 && 요청 상태가 주문 중 일 때에만 취소 가능하도록 설계
- Order: 고객이 주문 수락 행위를 하려고 하면 실패하는 테스트 케이스 추가
- Order: OrderController에 Swagger 누락된 부분 추가

## ✅ 테스트
- [x] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?