### PR TITLE
feat(ai): AI 프롬프트 목록 조회 시 PageResponse 타입으로 반환하도록 변경

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/controller/AiPromptController.java
@@ -4,7 +4,6 @@ import static com.sparta.delivery.backend.ai.internal.AiSwaggerMessage.*;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -20,6 +19,7 @@ import com.sparta.delivery.backend.ai.dto.ReqCreateAiPromptDto;
 import com.sparta.delivery.backend.ai.dto.ResCreateAiPromptDto;
 import com.sparta.delivery.backend.ai.dto.ResReadAiPromptDto;
 import com.sparta.delivery.backend.ai.service.AiPromptService;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -40,7 +40,7 @@ public class AiPromptController {
 	private final AiPromptService aiPromptService;
 
 	@Operation(summary = "AI 프롬프트 생성",
-		description = "요청한 메세지에 따라 AI 프롬프트를 작성합니다. MANAGER와 OWNER만 사용 가능합니다.")
+		description = "요청한 메세지에 따라 AI 프롬프트를 작성합니다. MASTER, MANAGER, OWNER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "AI 프롬프트가 생성되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResCreateAiPromptDto.class))),
@@ -64,7 +64,7 @@ public class AiPromptController {
 	}
 
 	@Operation(summary = "AI 프롬프트 목록 조회",
-		description = "AI 프롬프트 요청 목록을 확인합니다. MANAGER만 사용 가능합니다.")
+		description = "AI 프롬프트 요청 목록을 확인합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "AI 프롬프트 요청 목록을 조회했습니다.",
 			content = @Content(mediaType = "application/json", examples = {
@@ -78,9 +78,9 @@ public class AiPromptController {
 	@PageableAsQueryParam
 	@GetMapping
 	@PreAuthorize("isAuthenticated() && hasAnyRole('MASTER', 'MANAGER')")
-	public ResponseEntity<Page<ResReadAiPromptDto>> getAllAiPrompt(
+	public ResponseEntity<PageResponse<ResReadAiPromptDto>> getAllAiPrompt(
 		@ParameterObject @PageableDefault Pageable pageable) {
-		Page<ResReadAiPromptDto> responseDtoList = aiPromptService.getAllAiPrompts(pageable);
+		PageResponse<ResReadAiPromptDto> responseDtoList = aiPromptService.getAllAiPrompts(pageable);
 
 		return ResponseEntity.ok(responseDtoList);
 	}

--- a/src/main/java/com/sparta/delivery/backend/ai/internal/AiSwaggerMessage.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/internal/AiSwaggerMessage.java
@@ -32,41 +32,23 @@ public class AiSwaggerMessage {
 
 	public static final String AI_PROMPT_LIST_EXAMPLE = """
 			{
-			  "content": [
-				{
-				  "id": "e0866968-d417-469a-98e8-7ee6275ce170",
-				  "reqMessage": "치즈와 베이컨이 들어간 햄버거 메뉴의 음식 설명을 추천해줘",
-				  "resMessage": "고소한 치즈와 짭짤한 베이컨의 환상적인 만남! 풍미 가득한 햄버거",
-				  "createdAt": "2025-10-13T06:49:42.431683Z",
-				  "createdBy": 1
-				}
-			  ],
-			  "pageable": {
-				"pageNumber": 0,
-				"pageSize": 1,
-				"sort": {
-				  "empty": false,
-				  "sorted": true,
-				  "unsorted": false
-				},
-				"offset": 0,
-				"paged": true,
-				"unpaged": false
-			  },
-			  "last": true,
-			  "totalPages": 1,
-			  "totalElements": 1,
-			  "size": 1,
-			  "number": 0,
-			  "sort": {
-				"empty": false,
-				"sorted": true,
-				"unsorted": false
-			  },
-			  "first": true,
-			  "numberOfElements": 1,
-			  "empty": false
-			}
+		    "content": [
+		      {
+		        "id": "66201786-2dfa-4696-87d1-72a32f6f78f0",
+		        "reqMessage": "치즈와 베이컨이 들어간 햄버거 메뉴의 음식 설명을 추천해줘",
+		        "resMessage": "고소한 치즈와 짭짤한 베이컨의 환상적인 만남! 육즙 가득 패티와 완벽 조화!\\n",
+		        "createdAt": "2025-10-16T03:48:10.827628Z",
+		        "createdBy": 1
+		      }
+		    ],
+		    "currentPage": 0,
+		    "pageSize": 20,
+		    "totalElements": 1,
+		    "totalPages": 1,
+		    "first": true,
+		    "last": true,
+		    "hasNext": false
+		  }
 		""";
 
 }

--- a/src/main/java/com/sparta/delivery/backend/ai/service/AiPromptService.java
+++ b/src/main/java/com/sparta/delivery/backend/ai/service/AiPromptService.java
@@ -10,6 +10,7 @@ import com.sparta.delivery.backend.ai.dto.ResCreateAiPromptDto;
 import com.sparta.delivery.backend.ai.dto.ResReadAiPromptDto;
 import com.sparta.delivery.backend.ai.entity.AiPrompt;
 import com.sparta.delivery.backend.ai.repository.AiPromptRepository;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,9 +36,11 @@ public class AiPromptService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ResReadAiPromptDto> getAllAiPrompts(Pageable pageable) {
-		return aiPromptRepository.findAll(pageable)
+	public PageResponse<ResReadAiPromptDto> getAllAiPrompts(Pageable pageable) {
+		Page<ResReadAiPromptDto> responseDtoPage = aiPromptRepository.findAll(pageable)
 			.map(ResReadAiPromptDto::from);
+
+		return PageResponse.of(responseDtoPage);
 	}
 
 }

--- a/src/main/java/com/sparta/delivery/backend/region/controller/DongController.java
+++ b/src/main/java/com/sparta/delivery/backend/region/controller/DongController.java
@@ -47,7 +47,7 @@ public class DongController {
 
 	private final DongService dongService;
 
-	@Operation(summary = "동 생성", description = "새로운 동을 등록합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "동 생성", description = "새로운 동을 등록합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "동이 생성되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResCreateDongDto.class))),
@@ -86,7 +86,7 @@ public class DongController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDtoList);
 	}
 
-	@Operation(summary = "동 목록 조회", description = "등록된 동 목록을 조회합니다. MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
+	@Operation(summary = "동 목록 조회", description = "등록된 동 목록을 조회합니다. MASTER, MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "동 목록을 조회했습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResReadDongDto.class))),
@@ -109,7 +109,7 @@ public class DongController {
 		return ResponseEntity.ok(responseDtoList);
 	}
 
-	@Operation(summary = "동 수정", description = "기존의 동을 수정합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "동 수정", description = "기존의 동을 수정합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "동이 수정되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResUpdateDongDto.class))),
@@ -148,7 +148,7 @@ public class DongController {
 		return ResponseEntity.ok(responseDto);
 	}
 
-	@Operation(summary = "동 삭제", description = "기존의 동을 삭제합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "동 삭제", description = "기존의 동을 삭제합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "동이 삭제되었습니다.",
 			content = @Content()),

--- a/src/main/java/com/sparta/delivery/backend/region/controller/SidoController.java
+++ b/src/main/java/com/sparta/delivery/backend/region/controller/SidoController.java
@@ -46,7 +46,7 @@ public class SidoController {
 
 	private final SidoService sidoService;
 
-	@Operation(summary = "시·도 생성", description = "새로운 시·도를 등록합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·도 생성", description = "새로운 시·도를 등록합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "시·도가 생성되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResCreateSidoDto.class))),
@@ -80,7 +80,7 @@ public class SidoController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDtoList);
 	}
 
-	@Operation(summary = "시·도 목록 조회", description = "등록된 시·도 목록을 조회합니다. MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
+	@Operation(summary = "시·도 목록 조회", description = "등록된 시·도 목록을 조회합니다. MASTER, MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "시·도 목록을 조회했습니다.",
 			content = @Content(mediaType = "application/json",
@@ -99,7 +99,7 @@ public class SidoController {
 		return ResponseEntity.ok(responseDtoList);
 	}
 
-	@Operation(summary = "시·도 수정", description = "기존의 시·도를 수정합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·도 수정", description = "기존의 시·도를 수정합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "시·도가 수정되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResUpdateSidoDto.class))),
@@ -136,7 +136,7 @@ public class SidoController {
 		return ResponseEntity.ok(responseDto);
 	}
 
-	@Operation(summary = "시·도 삭제", description = "기존의 시·도를 삭제합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·도 삭제", description = "기존의 시·도를 삭제합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "시·도가 삭제되었습니다.",
 			content = @Content()),

--- a/src/main/java/com/sparta/delivery/backend/region/controller/SigunguController.java
+++ b/src/main/java/com/sparta/delivery/backend/region/controller/SigunguController.java
@@ -47,7 +47,7 @@ public class SigunguController {
 
 	private final SigunguService sigunguService;
 
-	@Operation(summary = "시·군·구 생성", description = "새로운 시·군·구를 등록합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·군·구 생성", description = "새로운 시·군·구를 등록합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "시·군·구가 생성되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResCreateSigunguDto.class))),
@@ -86,7 +86,7 @@ public class SigunguController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDtoList);
 	}
 
-	@Operation(summary = "시·군·구 목록 조회", description = "등록된 시·군·구 목록을 조회합니다. MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
+	@Operation(summary = "시·군·구 목록 조회", description = "등록된 시·군·구 목록을 조회합니다. MASTER, MANAGER, OWNER, CUSTOMER가 사용가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "시·군·구 목록을 조회했습니다.",
 			content = @Content(mediaType = "application/json",
@@ -111,7 +111,7 @@ public class SigunguController {
 		return ResponseEntity.ok(responseDtoList);
 	}
 
-	@Operation(summary = "시·군·구 수정", description = "기존의 시·군·구를 수정합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·군·구 수정", description = "기존의 시·군·구를 수정합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "시·군·구가 수정되었습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResUpdateSigunguDto.class))),
@@ -150,7 +150,7 @@ public class SigunguController {
 		return ResponseEntity.ok(responseDto);
 	}
 
-	@Operation(summary = "시·군·구 삭제", description = "기존의 시·군·구를 삭제합니다. MANAGER만 사용 가능합니다.")
+	@Operation(summary = "시·군·구 삭제", description = "기존의 시·군·구를 삭제합니다. MASTER와 MANAGER만 사용 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "시·군·구가 삭제되었습니다.",
 			content = @Content()),

--- a/src/test/java/com/sparta/delivery/backend/ai/service/AiPromptServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/ai/service/AiPromptServiceTest.java
@@ -22,6 +22,7 @@ import com.sparta.delivery.backend.ai.dto.ResCreateAiPromptDto;
 import com.sparta.delivery.backend.ai.dto.ResReadAiPromptDto;
 import com.sparta.delivery.backend.ai.entity.AiPrompt;
 import com.sparta.delivery.backend.ai.repository.AiPromptRepository;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class AiPromptServiceTest {
@@ -81,10 +82,10 @@ public class AiPromptServiceTest {
 			given(aiPromptRepository.findAll(pageable)).willReturn(page);
 
 			// when
-			Page<ResReadAiPromptDto> responseDto = aiPromptService.getAllAiPrompts(pageable);
+			PageResponse<ResReadAiPromptDto> responseDto = aiPromptService.getAllAiPrompts(pageable);
 
 			// then
-			assertThat(responseDto).hasSize(1);
+			assertThat(responseDto.getContent()).hasSize(1);
 			assertThat(responseDto.getContent().get(0).getReqMessage()).isEqualTo("요청");
 			assertThat(responseDto.getContent().get(0).getResMessage()).isEqualTo("응답");
 			then(aiPromptRepository).should(times(1)).findAll(pageable);


### PR DESCRIPTION
## 📌 개요
- AI 프롬프트 목록 조회 시 PageResponse 타입으로 반환하도록 변경

## 🔨 변경 사항
- AI 프롬프트 목록 조회 시 PageResponse 타입으로 반환하도록 변경
- 각 컨트롤러마다 swagger 설명에 MASTER 추가

## ✅ 테스트
- [ ] 단위/통합 테스트 통과 확인
- [x] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?