### PR TITLE
Feat/fix store menu,order,cart

### DIFF
--- a/src/main/java/com/sparta/delivery/backend/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/delivery/backend/cart/entity/Cart.java
@@ -45,6 +45,9 @@ public class Cart {
 	@Column(name = "deleted_at")
 	private Instant deletedAt;
 
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+
 	@Builder
 	public Cart(Customer customer, StoreMenu menu) {
 		this.customer = customer;
@@ -56,8 +59,9 @@ public class Cart {
 		this.createAt = Instant.now();
 	}
 
-	public void softDelete() {
+	public void softDelete(Long userId) {
 		this.deletedAt = Instant.now();
+		this.deletedBy = userId;
 	}
 
 }

--- a/src/main/java/com/sparta/delivery/backend/cart/repository/CartRepository.java
+++ b/src/main/java/com/sparta/delivery/backend/cart/repository/CartRepository.java
@@ -22,4 +22,6 @@ public interface CartRepository extends JpaRepository<Cart, UUID>, CartRepositor
 
 	@Query("SELECT DISTINCT c FROM Cart c JOIN FETCH c.customer cu JOIN FETCH cu.user WHERE c.id = :cartId")
 	Optional<Cart> findByIdWithCustomerAndUser(@Param("cartId") UUID cartId);
+
+	List<Cart> findAllByMenuIdAndDeletedAtIsNull(UUID menuId);
 }

--- a/src/main/java/com/sparta/delivery/backend/cart/service/CartService.java
+++ b/src/main/java/com/sparta/delivery/backend/cart/service/CartService.java
@@ -82,7 +82,7 @@ public class CartService {
 		}
 
 		// 메뉴 row 삭제
-		cart.softDelete();
+		cart.softDelete(user.getId());
 		Cart savedCart = cartRepository.save(cart);
 
 		return new ResDeleteCartItemDto(savedCart.getId(),savedCart.getMenu().getName());
@@ -95,7 +95,7 @@ public class CartService {
 		List<Cart> carts = cartRepository.findAllByCustomerIdAndDeletedAtIsNull(customer.getId());
 
 		for(Cart cart : carts) {
-			cart.softDelete();
+			cart.softDelete(user.getId());
 		}
 
 		List<Cart> savedCarts = cartRepository.saveAll(carts);

--- a/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
@@ -80,9 +80,9 @@ public class OrderController {
 
 	// 주문 상세 정보 조회
 	@GetMapping("/{orderId}")
-	@Operation(summary = "주문 내역 상세 조회", description = "자신의 주문 내역을 페이징 형태로 조회합니다.")
+	@Operation(summary = "주문 내역 상세 조회", description = "자신의 주문 내역을 상세 조회합니다.")
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "주문 내역 조회 성공", content = @Content(schema = @Schema(implementation = ResGetListOrderDto.class))),
+		@ApiResponse(responseCode = "200", description = "주문 내역 조회 성공", content = @Content(schema = @Schema(implementation = ResGetOrderDto.class))),
 		@ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 정보")
 	})
 	public ResponseEntity<ResGetOrderDto> getOrderById(

--- a/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/delivery/backend/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.backend.order.controller;
 
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.order.dto.*;
 import com.sparta.delivery.backend.order.service.OrderService;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
@@ -61,7 +62,7 @@ public class OrderController {
 		@ApiResponse(responseCode = "200", description = "주문 내역 조회 성공", content = @Content(schema = @Schema(implementation = ResGetListOrderDto.class))),
 		@ApiResponse(responseCode = "400", description = "유효하지 않은 사용자 정보")
 	})
-	public ResponseEntity<Page<ResGetListOrderDto>> getOrdersByUserId(
+	public ResponseEntity<PageResponse<ResGetListOrderDto>> getOrdersByUserId(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestParam("page") int page,
 		@RequestParam("size") int size
@@ -73,7 +74,7 @@ public class OrderController {
 		@RequestParam(required = false) String endDate        // 조회 종료일
 		*/
 	) {
-		Page<ResGetListOrderDto> orders = orderService.getOrdersByUser(userDetails.getUser(), page - 1, size);
+		PageResponse<ResGetListOrderDto> orders = orderService.getOrdersByUser(userDetails.getUser(), page - 1, size);
 		return ResponseEntity.ok(orders);
 	}
 

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -163,28 +163,25 @@ public class OrderService {
 	public void updateOrderStatus(User user, UUID orderId, ReqUpdateOrderStatusDto reqUpdateOrderStatusDto) {
 		// 단건 주문 조회
 		Order order = findOrderOrThrow(orderId);
+		
+		// 권한도 있고
+		validateRoleAccess(user, order);
 
-		// 고객 취소 허용: 주문 생성 후 5분 이내 && 요청 상태가 주문 중(취소 가능)
-		boolean isCustomer = user.getRole() == UserRoleEnum.CUSTOMER;
+		// 주문 생성 후 5분 이내 && 요청 상태가 주문 중(취소 가능) 이라면
 		boolean isCancelRequest = reqUpdateOrderStatusDto.getOrderStatus() == OrderStatus.CANCELLED;
-
-		if (isCustomer && isCancelRequest) {
+		if (isCancelRequest) {
 			if (order.getOrderStatus() != OrderStatus.ORDERED) {
 				throw new IllegalStateException("주문중 상태에만 주문을 취소할 수 있습니다.");
 			}
 			long minutesSinceOrder = ChronoUnit.MINUTES.between(order.getCreatedAt(), Instant.now());
 			if (minutesSinceOrder <= 5) {
 				order.updateOrderStatus(user, reqUpdateOrderStatusDto);
+				// 고객 취소 허용
 				orderRepository.save(order);
 				return;
 			} else {
 				throw new IllegalStateException("주문 5분 이내에만 주문을 취소할 수 있습니다.");
 			}
-		}
-
-		// 권한 확인: 이 주문의 가게 주인인지 확인
-		if (!order.getStore().getOwner().getUser().getId().equals(user.getId())) {
-			throw new IllegalStateException("Owner만 주문 상태를 변경할 수 있습니다.");
 		}
 
 		order.updateOrderStatus(user, reqUpdateOrderStatusDto);

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -21,6 +21,7 @@ import com.sparta.delivery.backend.customer.entity.Customer;
 import com.sparta.delivery.backend.customer.entity.CustomerAddress;
 import com.sparta.delivery.backend.customer.repository.CustomerAddressRepository;
 import com.sparta.delivery.backend.customer.repository.CustomerRepository;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.order.dto.ReqCreateOrderDto;
 import com.sparta.delivery.backend.order.dto.ReqUpdateOrderStatusDto;
 import com.sparta.delivery.backend.order.dto.ResCheckOutOrderDto;
@@ -117,7 +118,7 @@ public class OrderService {
 
 	// Customer, Owner: 전체 주문 내역 조회
 	@Transactional(readOnly = true)
-	public Page<ResGetListOrderDto> getOrdersByUser(User user, int page, int size) {
+	public PageResponse<ResGetListOrderDto> getOrdersByUser(User user, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
 
 		// DB에서 Role 기반 필터링 후 조회
@@ -135,10 +136,12 @@ public class OrderService {
 			default -> throw new IllegalArgumentException("지원하지 않는 사용자 유형입니다.");
 		};
 
-		return orders.map(order -> {
+		Page<ResGetListOrderDto> mappedPage = orders.map(order -> {
 			int totalPrice = calculateTotalPrice(order);
 			return ResGetListOrderDto.from(order, totalPrice);
 		});
+
+		return PageResponse.of(mappedPage);
 	}
 
 	// 주문 상세 조회

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -103,7 +103,7 @@ public class OrderService {
 				.order(order)
 				.storeMenu(cart.getMenu())
 				.build());
-			cart.softDelete();
+			cart.softDelete(user.getId());
 		});
 
 		return order.getId(); // 생성된 Order ID 반환

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -13,8 +13,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.sparta.delivery.backend.address.entity.Address;
-import com.sparta.delivery.backend.address.repository.AddressRepository;
 import com.sparta.delivery.backend.cart.entity.Cart;
 import com.sparta.delivery.backend.cart.repository.CartRepository;
 import com.sparta.delivery.backend.customer.entity.Customer;
@@ -119,7 +117,7 @@ public class OrderService {
 	// Customer, Owner: 전체 주문 내역 조회
 	@Transactional(readOnly = true)
 	public PageResponse<ResGetListOrderDto> getOrdersByUser(User user, int page, int size) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by("sortOrder").ascending());
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createAt").ascending());
 
 		// DB에서 Role 기반 필터링 후 조회
 		Page<Order> orders = switch (user.getRole()) {

--- a/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
+++ b/src/main/java/com/sparta/delivery/backend/order/service/OrderService.java
@@ -214,13 +214,14 @@ public class OrderService {
 	}
 
 	/** --------------------- Helper --------------------- **/
-	// Owner 본인 확인 || Manager 검증
+	// Customer, Owner 본인 확인 || Manager 검증
 	private void validateRoleAccess(User user, Order order) {
+		boolean isCustomer = order.getCustomer().getUser().getId().equals(user.getId());
 		boolean isOwner = order.getStore().getOwner().getUser().getId().equals(user.getId());
 		boolean isManager = user.getRole() == UserRoleEnum.MANAGER;
 		boolean isMaster = user.getRole() == UserRoleEnum.MASTER;
 
-		if (!(isOwner || isManager || isMaster)) {
+		if (!(isCustomer || isOwner || isManager || isMaster)) {
 			throw new IllegalStateException("접근 권한이 없습니다.");
 		}
 	}

--- a/src/main/java/com/sparta/delivery/backend/store/menu/controller/StoreMenuController.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/controller/StoreMenuController.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.backend.store.menu.controller;
 
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.security.UserDetailsImpl;
 import com.sparta.delivery.backend.store.menu.dto.*;
 import com.sparta.delivery.backend.store.menu.service.StoreMenuService;
@@ -48,13 +49,13 @@ public class StoreMenuController {
 			@ApiResponse(responseCode = "200", description = "메뉴 목록 조회 성공"),
 			@ApiResponse(responseCode = "400", description = "가게 없음")
 	})
-	public ResponseEntity<Page<ResGetListStoreMenuDto>> getAllStoreMenusByStoreId(
+	public ResponseEntity<PageResponse<ResGetListStoreMenuDto>> getAllStoreMenusByStoreId(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID storeId,
 		@RequestParam("page") int page,
 		@RequestParam("size") int size
 	) {
-		Page<ResGetListStoreMenuDto> menus = storeMenuService.getStoreMenusByStoreId(userDetails.getUser(), storeId, page - 1, size);
+		PageResponse<ResGetListStoreMenuDto> menus = storeMenuService.getStoreMenusByStoreId(userDetails.getUser(), storeId, page - 1, size);
 		return ResponseEntity.ok(menus);
 	}
 

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sparta.delivery.backend.cart.entity.Cart;
+import com.sparta.delivery.backend.cart.repository.CartRepository;
 import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.image.entity.Image;
 import com.sparta.delivery.backend.image.repository.ImageRepository;
@@ -35,6 +37,7 @@ public class StoreMenuService {
 	private final StoreMenuRepository storeMenuRepository;
 	private final StoreRepository storeRepository;
 	private final ImageRepository imageRepository;
+	private final CartRepository cartRepository;
 
 	/** 생성 **/
 	@Transactional
@@ -203,6 +206,13 @@ public class StoreMenuService {
 		}
 
 		storeMenu.setHiddenAt(reqUpdateVisibilityDto.isHidden());
+
+		if (wantHidden) {
+			List<Cart> carts = cartRepository.findAllByMenuIdAndDeletedAtIsNull(menuId);
+			for (Cart cart : carts) {
+				cart.softDelete(user.getId());
+			}
+		}
 	}
 
 	/** 삭제 **/

--- a/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
+++ b/src/main/java/com/sparta/delivery/backend/store/menu/service/StoreMenuService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.image.entity.Image;
 import com.sparta.delivery.backend.image.repository.ImageRepository;
 import com.sparta.delivery.backend.store.entity.Store;
@@ -78,7 +79,7 @@ public class StoreMenuService {
 
 	// 전체 메뉴 조회 (페이징)
 	@Transactional(readOnly = true)
-	public Page<ResGetListStoreMenuDto> getStoreMenusByStoreId(
+	public PageResponse<ResGetListStoreMenuDto> getStoreMenusByStoreId(
 		User user,
 		UUID storeId,
 		int page,
@@ -111,11 +112,13 @@ public class StoreMenuService {
 		*/
 
 		// 메뉴가 하나도 없어도 빈 페이지는 반환
+		// 메뉴가 하나도 없어도 빈 페이지는 반환
 		if (storeMenuList == null || storeMenuList.isEmpty()) {
-			return Page.empty(pageable);
+			return PageResponse.of(Page.empty(pageable));
 		}
 
-		return storeMenuList.map(ResGetListStoreMenuDto::new);
+		Page<ResGetListStoreMenuDto> mappedPage = storeMenuList.map(ResGetListStoreMenuDto::new);
+		return PageResponse.of(mappedPage);
 	}
 
 	/** 수정 **/

--- a/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/order/service/OrderServiceTest.java
@@ -30,6 +30,7 @@ import com.sparta.delivery.backend.customer.entity.Customer;
 import com.sparta.delivery.backend.customer.entity.CustomerAddress;
 import com.sparta.delivery.backend.customer.repository.CustomerAddressRepository;
 import com.sparta.delivery.backend.customer.repository.CustomerRepository;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.image.entity.Image;
 import com.sparta.delivery.backend.order.dto.ReqCreateOrderDto;
 import com.sparta.delivery.backend.order.dto.ReqUpdateOrderStatusDto;
@@ -317,7 +318,7 @@ class OrderServiceTest {
 			when(orderRepository.findByCustomerId(any(), any(Pageable.class))).thenReturn(mockPage);
 
 			/* when */
-			Page<?> result = orderService.getOrdersByUser(customerUser, 0, 10);
+			PageResponse<?> result = orderService.getOrdersByUser(customerUser, 0, 10);
 
 			/* then */
 			assertEquals(1, result.getTotalElements());
@@ -333,7 +334,7 @@ class OrderServiceTest {
 			when(orderRepository.findByStoreOwnerId(any(), any(Pageable.class))).thenReturn(mockPage);
 
 			/* when */
-			Page<?> result = orderService.getOrdersByUser(ownerUser, 0, 10);
+			PageResponse<?> result = orderService.getOrdersByUser(ownerUser, 0, 10);
 
 			/* then */
 			assertEquals(1, result.getContent().size());

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.sparta.delivery.backend.cart.repository.CartRepository;
 import com.sparta.delivery.backend.customer.entity.Customer;
 import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.image.entity.Image;
@@ -57,6 +58,9 @@ class StoreMenuServiceTest {
 
 	@InjectMocks
 	private StoreMenuService storeMenuService;
+
+	@Mock
+	private CartRepository cartRepository;
 
 	private User user;
 	private Owner owner;

--- a/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
+++ b/src/test/java/com/sparta/delivery/backend/store/menu/service/StoreMenuServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sparta.delivery.backend.customer.entity.Customer;
+import com.sparta.delivery.backend.global.common.dto.PageResponse;
 import com.sparta.delivery.backend.image.entity.Image;
 import com.sparta.delivery.backend.image.repository.ImageRepository;
 import com.sparta.delivery.backend.owner.entity.Owner;
@@ -423,7 +424,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(customerUser, storeId, 0,
+			PageResponse<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(customerUser, storeId, 0,
 				10);
 
 			/* then */
@@ -472,7 +473,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(differentOwner, storeId, 0,
+			PageResponse<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(differentOwner, storeId, 0,
 				10);
 
 			/* then */
@@ -511,7 +512,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
+			PageResponse<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
 				10);
 
 			/* then */
@@ -601,7 +602,7 @@ class StoreMenuServiceTest {
 				.thenReturn(pageResult);
 
 			/* when */
-			Page<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
+			PageResponse<ResGetListStoreMenuDto> resGetListStoreMenuDto = storeMenuService.getStoreMenusByStoreId(user, storeId, 0,
 				10);
 
 			/* then */
@@ -627,12 +628,12 @@ class StoreMenuServiceTest {
 				.thenReturn(Page.empty(pageable));
 
 			/* when */
-			Page<ResGetListStoreMenuDto> result =
+			PageResponse<ResGetListStoreMenuDto> result =
 				storeMenuService.getStoreMenusByStoreId(user, storeId, page, size);
 
 			/* then */
 			assertNotNull(result);
-			assertTrue(result.isEmpty());
+			assertTrue(result.getContent().isEmpty());
 			verify(storeRepository, times(1)).findById(storeId);
 			verify(storeMenuRepository, times(1))
 				.findAllByStoreIdAndDeletedAtIsNull(storeId, pageable);


### PR DESCRIPTION
## 📌 개요
- 전체적인 수정

## 🔨 변경 사항
- Page -> PageResponse 반환하도록 수정
- 메뉴를 숨김 처리할 때 점주에게 장바구니에 담긴 메뉴들이 일괄적으로 삭제되는 cart.softDelete(userId) 를 거치게 된다. 이때 Cart 의 deleteAt에 점주의 userId 가 삽입된다.
- order 목록 조회할때 creatAt 으로 정렬되게끔 수정
- order 상세 조회 시 고객 본인이 조회할 수 있도록 수정
- orderStatus 변경 시에도 customer 본인인지 검증

## ✅ 테스트
- [x] 단위/통합 테스트 통과 확인
- [ ] 로컬 실행 후 정상 동작 확인

## ☑️ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 문서화 (ERD, API 명세서 등) 반영

## 🙋 리뷰 요청사항(선택)
- (예시)이런 A라는 문제가 있는데, B와 C중에 어떤게 괜찮을까요?